### PR TITLE
Necessary columns logic usable via utility functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,12 +148,12 @@ show_missing = true
 
 [tool.coverage.run]
 omit = [
-     "src/dask_awkward/lib/io/scratch.py",
-     "src/dask_awkward/tests/test_*.py",
-     "src/dask_awkward/tests/__init__.py",
-     "src/dask_awkward/version.py",
+     "*/lib/io/scratch.py",
+     "*/tests/test_*.py",
+     "*/tests/__init__.py",
+     "*/version.py",
 ]
-source = ["src/dask_awkward"]
+source = ["src/"]
 
 [tool.ruff]
 ignore = ["E501", "E402"]

--- a/src/dask_awkward/lib/inspect.py
+++ b/src/dask_awkward/lib/inspect.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 import dask_awkward.lib.optimize as opt
 from dask_awkward.lib.core import Array, Record, Scalar
@@ -9,12 +9,9 @@ from dask_awkward.lib.core import Array, Record, Scalar
 def necessary_columns(
     collection: Array | Record | Scalar,
     strategy: Literal["brute"] | Literal["getitem"],
-) -> dict:
+) -> dict[str, Any]:
     if strategy == "brute":
-        necessary = opt._necessary_columns_brute(collection.dask)
-        return {None: necessary}
+        return opt._necessary_columns_brute(collection.dask)
     elif strategy == "getitem":
         return opt._layers_and_columns_getitem(collection.dask)
-    raise ValueError(  # pragma: no cover
-        "strategy argument should be 'brute' or 'getitem'"
-    )
+    raise ValueError("strategy argument should be 'brute' or 'getitem'")

--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -109,7 +109,7 @@ def from_parquet(
     )
     label = "read-parquet"
     token = tokenize(
-        tok, ignore_metadata, columns, filters, scan_files, split_row_groups
+        tok, paths, ignore_metadata, columns, filters, scan_files, split_row_groups
     )
 
     # same as ak_metadata_from_parquet

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+import warnings
 from collections.abc import Hashable, Mapping
 from typing import Any
 
@@ -34,8 +35,13 @@ def optimize(
         raise NotImplementedError(
             '"chained" is not supported (yet), use "simple-getitem" or "brute-force".'
         )
-    else:
+    elif confopt == "none":
         pass
+    else:
+        warnings.warn(
+            f"column-projection-optimization option {confopt!r} is unknown; "
+            "no column projection optimization will be executed."
+        )
 
     # Perform Blockwise optimizations for HLG input
     dsk = optimize_blockwise(dsk, keys=keys)

--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -163,24 +163,39 @@ def unnamed_root_ds() -> Array:
             {
                 "minutes": 33,
                 "passes": {"to": [2, 5, 6], "success": [True, True, False]},
+                "assists": [
+                    {"distance": 3.3, "scorer": 6},
+                    {"distance": 4.4, "scorer": 6},
+                ],
             },
             {
                 "minutes": 34,
                 "passes": {"to": [5, 6, 7, 8], "success": [False, False, True, True]},
+                "assists": [],
             },
         ],
         [
             {
                 "minutes": 24,
                 "passes": {"to": [0, 3, 4, 5], "success": [True, True, True, False]},
+                "assists": [
+                    {"distance": 10.3, "scorer": 0},
+                    {"distance": 14.0, "scorer": 0},
+                ],
             },
             {
                 "minutes": 3,
                 "passes": {"to": [], "success": []},
+                "assists": [
+                    {"distance": 3.3, "scorer": 0},
+                    {"distance": 2.3, "scorer": 4},
+                    {"distance": 1.0, "scorer": 5},
+                ],
             },
             {
                 "minutes": 18,
                 "passes": {"to": [0, 3, 4, 5], "success": [False, True, True, False]},
+                "assists": [{"distance": 4.3, "scorer": 0}],
             },
         ],
     ]

--- a/src/dask_awkward/lib/utils.py
+++ b/src/dask_awkward/lib/utils.py
@@ -8,13 +8,13 @@ from dask_awkward.lib.core import Array, Record, Scalar
 
 def necessary_columns(
     collection: Array | Record | Scalar,
-    method: Literal["brute"] | Literal["getitem"],
+    strategy: Literal["brute"] | Literal["getitem"],
 ) -> dict:
-    if method == "brute":
+    if strategy == "brute":
         necessary = opt._necessary_columns_brute(collection.dask)
         return {None: necessary}
-    elif method == "getitem":
+    elif strategy == "getitem":
         return opt._layers_and_columns_getitem(collection.dask)
     raise ValueError(  # pragma: no cover
-        "method argument should be 'brute' or 'getitem'"
+        "strategy argument should be 'brute' or 'getitem'"
     )

--- a/src/dask_awkward/lib/utils.py
+++ b/src/dask_awkward/lib/utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import dask_awkward.lib.optimize as opt
+from dask_awkward.lib.core import Array, Record, Scalar
+
+
+def necessary_columns(
+    collection: Array | Record | Scalar,
+    method: Literal["brute"] | Literal["getitem"],
+) -> dict:
+    if method == "brute":
+        necessary = opt._necessary_columns_brute(collection.dask)
+        return {None: necessary}
+    elif method == "getitem":
+        return opt._layers_and_columns_getitem(collection.dask)
+    raise ValueError(  # pragma: no cover
+        "method argument should be 'brute' or 'getitem'"
+    )

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+import dask_awkward as dak
+from dask_awkward.lib.inspect import necessary_columns
+
+
+def test_necessary_columns(
+    daa: dak.Array,
+    tmpdir_factory: pytest.TempdirFactory,
+) -> None:
+    dname = tmpdir_factory.mktemp("pq")
+    dak.to_parquet(daa, str(dname), compute=True)
+    ds = dak.from_parquet(str(dname))
+    aioname = list(ds.dask.layers.items())[0][0]
+    assert necessary_columns(ds.points.x, "brute") == {aioname: ["points.x"]}
+    assert necessary_columns(ds.points.x, "getitem") == {aioname: ["points"]}
+    with pytest.raises(ValueError, match="strategy argument should"):
+        assert necessary_columns(ds.points, "okokok")  # type: ignore

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -25,9 +25,9 @@ def test_requested_columns(caa_parquet):
         if isinstance(v, AwkwardIOLayer):
             continue
         if k.startswith("points"):
-            assert o._requested_columns(v) == {"points"}
+            assert o._requested_columns_getitem(v) == {"points"}
         if k.startswith("x"):
-            assert o._requested_columns(v) == {"x"}
+            assert o._requested_columns_getitem(v) == {"x"}
 
 
 def test_config_adjust_1(caa_parquet):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import awkward as ak
 import pytest
 
@@ -65,7 +67,7 @@ def test_zip_tuple_input(caa: ak.Array, daa: dak.Array) -> None:
     assert_eq(dz2, cz2)
 
 
-def test_zip_bad_input(caa: ak.Array, daa: dak.Array) -> None:
+def test_zip_bad_input(daa: dak.Array) -> None:
     da1 = daa.points.x
     gd = (x for x in (da1, da1))
     with pytest.raises(DaskAwkwardNotImplemented, match="only sized iterables"):
@@ -108,8 +110,8 @@ def test_fill_none(vf: int | float | str, axis: int | None) -> None:
 
 @pytest.mark.parametrize("axis", [0, 1, -1])
 def test_is_none(axis: int) -> None:
-    a = [[1, 2, None], None, None, [], [None], [5, 6, 7, None], [1, 2], None]
-    b = [[None, 2, 1], [None], [], None, [7, 6, None, 5], [None, None]]
+    a: list[Any] = [[1, 2, None], None, None, [], [None], [5, 6, 7, None], [1, 2], None]
+    b: list[Any] = [[None, 2, 1], [None], [], None, [7, 6, None, 5], [None, None]]
     c = dak.from_lists([a, b])
     with pytest.warns(UserWarning, match="compute on the first partition"):
         d = dak.is_none(c, axis=axis)


### PR DESCRIPTION
Adds a new `dask_awkward.lib.inspect` module with the `necessary_columns` function for inspecting which IO columns are necessary in a given graph.