### PR TITLE
fix: use new `backend` attribute instead of `nplike`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "awkward>2.0.0rc4",
+    "awkward>=2.0.0rc5",
     "dask>=2022.02.1",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "awkward>=2.0.0rc4",
+    "awkward>2.0.0rc4",
     "dask>=2022.02.1",
 ]
 dynamic = [

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1494,19 +1494,14 @@ def is_typetracer(obj: Any) -> bool:
         True if the `obj` is a typetracer like object.
 
     """
-    # array typetracer
-    if isinstance(obj, ak.Array):
-        if not obj.layout.nplike.known_shape and not obj.layout.nplike.known_data:
-            return True
-    # record typetracer
-    if isinstance(obj, ak.Record):
-        if (
-            not obj.layout.array.nplike.known_shape
-            and not obj.layout.array.nplike.known_data
-        ):
+    # array/record typetracer
+    if isinstance(obj, (ak.Array, ak.Record)):
+        backend = obj.layout.backend
+
+        if not backend.nplike.known_shape and not backend.nplike.known_data:
             return True
     # scalar-like typetracer
-    if isinstance(obj, (UnknownScalar, MaybeNone, OneOf)):
+    elif isinstance(obj, (UnknownScalar, MaybeNone, OneOf)):
         return True
     return False
 


### PR DESCRIPTION
scikit-hep/awkward#1922 changes the `ak.contents.Content`/`ak.record.Record` API to use a new high-level `backend` object instead of `nplike`. This is just to better encapsulate the difference between an array compatibility library, and a "backend". 

This PR adjusts the dask-awkward usage of the old `.nplike` attribute in favour of the new `.backend` object, which has a `.nplike` and `.index_nplike` member.

Note that this code has *not* been released yet, so I've bumped the `pyproject.toml` to look for a new version of awkward.