### PR TITLE
ci: add concurrency groups

### DIFF
--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -9,6 +9,10 @@ on:
     - '**.md'
   workflow_dispatch:
 
+concurrency:
+  group: 'conda-tests-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
 jobs:
   pytest:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,10 @@ on:
     - "**.md"
   workflow_dispatch:
 
+concurrency:
+  group: 'coverage-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-tests.yml
+++ b/.github/workflows/pypi-tests.yml
@@ -9,6 +9,10 @@ on:
     - '**.md'
   workflow_dispatch:
 
+concurrency:
+  group: 'pypi-tests-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
 jobs:
   pytest:
     strategy:


### PR DESCRIPTION
This PR adds the following YAML to the GitHub Actions CI configuration, so that multiple pushes cancel previous running jobs
```yaml
concurrency:
  group: '<NAME>-${{ github.head_ref || github.run_id }}'
  cancel-in-progress: true
```