### PR TITLE
feat: add future-proofing to typetracer

### DIFF
--- a/src/dask_awkward/lib/compat.py
+++ b/src/dask_awkward/lib/compat.py
@@ -1,0 +1,19 @@
+try:
+    from awkward._typetracer import MaybeNone, OneOf, UnknownScalar
+except ModuleNotFoundError:
+    from awkward._nplikes.typetracer import (
+        MaybeNone,
+        OneOf,
+        unknown_scalar,
+        is_unknown_scalar,
+    )
+else:
+
+    def is_unknown_scalar(obj) -> bool:
+        return isinstance(obj, UnknownScalar)
+
+    def unknown_scalar(dtype):
+        return UnknownScalar(dtype)
+
+
+__all__ = ("MaybeNone", "OneOf", "is_unknown_scalar", "unknown_scalar")

--- a/src/dask_awkward/lib/reducers.py
+++ b/src/dask_awkward/lib/reducers.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 import awkward as ak
 import numpy as np
-from awkward._typetracer import UnknownScalar
 
+from dask_awkward.lib.core import unknown_scalar
 from dask_awkward.lib.core import map_partitions, total_reduction_to_scalar
 from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
 
@@ -158,7 +158,7 @@ def count(
         return total_reduction_to_scalar(
             label="count",
             array=array,
-            meta=UnknownScalar(np.dtype(int)),
+            meta=unknown_scalar(np.dtype(int)),
             chunked_fn=ak.count,
             chunked_kwargs={"axis": 1},
             comb_fn=ak.sum,
@@ -196,7 +196,7 @@ def count_nonzero(
         return total_reduction_to_scalar(
             label="count_nonzero",
             array=array,
-            meta=UnknownScalar(np.dtype(int)),
+            meta=unknown_scalar(np.dtype(int)),
             chunked_fn=ak.count_nonzero,
             chunked_kwargs={"axis": 1},
             comb_fn=ak.sum,

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 import awkward as ak
 import numpy as np
-from awkward._typetracer import UnknownScalar
 
+from dask_awkward.lib.compat import unknown_scalar
 from dask_awkward.lib.core import (
     Array,
     map_partitions,
@@ -381,7 +381,7 @@ def num(
             return total_reduction_to_scalar(
                 label="num",
                 array=array,
-                meta=UnknownScalar(np.dtype(int)),
+                meta=unknown_scalar(np.dtype(int)),
                 chunked_fn=ak.num,
                 chunked_kwargs={"axis": 0},
                 comb_fn=ak.sum,


### PR DESCRIPTION
This PR anticipates backwards-incompatible changes to typetracer. We should hold off on merging this until awkward has released, and we're confident that it is needed.