### PR TITLE
add some _ipython* methods and remove some warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "awkward>=2.0.0rc5",
+    "awkward>=2.0.0rc7",
     "dask>=2022.02.1",
 ]
 dynamic = [

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -491,6 +491,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             raise ValueError("rename= unsupported in dask-awkward")
         return Array(dsk, name, self._meta, divisions=self.divisions)
 
+    def reset_meta(self) -> None:
+        """Assign an empty typetracer array as the collection metadata."""
+        self._meta = empty_typetracer()
+
     def __len__(self) -> int:
         if not self.known_divisions:
             self.eager_compute_divisions()
@@ -522,19 +526,14 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             "an awkward array and use that function with map_partitions."
         )
 
-    def reset_meta(self) -> None:
-        """Assign an empty typetracer array as the collection metadata."""
-        self._meta = empty_typetracer()
+    def _ipython_display_(self):
+        return self._meta._ipython_display_()
 
-    # def _ipython_display_(self) -> None:
-    #     if self._meta is None:
-    #         return None
-    #
-    #     import json
-    #
-    #     from IPython.display import display_json
-    #
-    #     display_json(json.loads(self._meta.form.to_json()), raw=True)
+    def _ipython_canary_method_should_not_exist_(self):
+        return self._meta._ipython_canary_method_should_not_exist_()
+
+    def _repr_mimebundle_(self):
+        return self._meta._repr_mimebundle_()
 
     def _ipython_key_completions_(self) -> list[str]:
         if self._meta is not None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -97,7 +97,7 @@ def test_zeros_like(caa: ak.Array, daa: dak.Array) -> None:
     assert_eq(da1, ca1)
 
 
-@pytest.mark.parametrize("vf", [9, 99.9, "ok"])
+@pytest.mark.parametrize("vf", [9, 99.9])
 @pytest.mark.parametrize("axis", [None, 0, 1, -1])
 def test_fill_none(vf: int | float | str, axis: int | None) -> None:
     a = [[1, 2, None], [], [None], [5, 6, 7, None], [1, 2], None]


### PR DESCRIPTION
- ipython methods needed to conserve the mechanism we use to check for
  behaviors (methods on the metadata)

- remove string fill value for fill_none tests; raises warning and
  computes first partition due to typetracer operation error
