### PR TITLE
Register with dask.sizeof

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ test = [
     "requests >=2.27.1",
 ]
 
+[project.entry-points."dask.sizeof"]
+awkward = "dask_awkward.sizeof:ak_array_sizeof_plugin"
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/dask_awkward/sizeof.py
+++ b/src/dask_awkward/sizeof.py
@@ -1,0 +1,10 @@
+from dask.sizeof import sizeof
+
+
+@sizeof.register_lazy("awkward")
+def register_awkward():
+    import awkward as ak
+
+    @sizeof.register(ak.Array)
+    def sizeof_ak_array(array):
+        return array.nbytes

--- a/src/dask_awkward/sizeof.py
+++ b/src/dask_awkward/sizeof.py
@@ -1,8 +1,4 @@
-from dask.sizeof import sizeof
-
-
-@sizeof.register_lazy("awkward")
-def register_awkward():
+def ak_array_sizeof_plugin(sizeof):
     import awkward as ak
 
     @sizeof.register(ak.Array)

--- a/tests/test_sizeof.py
+++ b/tests/test_sizeof.py
@@ -1,0 +1,8 @@
+import awkward as ak
+import dask.sizeof
+
+
+def test_sizeof():
+    x = ak.Array([[1, 2, 3], [4], [5, 6]])
+
+    assert dask.sizeof.sizeof(x) == x.nbytes


### PR DESCRIPTION
Use Dask's `dask.sizeof` entry-point to [register sizeof usage](https://docs.dask.org/en/stable/how-to/extend-sizeof.html) for `awkward.Array` object