### PR TITLE
`distributed.scheduler.allowed-imports` config update

### DIFF
--- a/src/dask_awkward/config.py
+++ b/src/dask_awkward/config.py
@@ -10,16 +10,7 @@ with open(fn) as f:
     defaults = yaml.safe_load(f)
 
 dask.config.update_defaults(defaults)
-dask.config.update_defaults(
-    {
-        "distributed": {
-            "scheduler": {
-                "allowed-imports": [
-                    "dask",
-                    "distributed",
-                    "dask_awkward",
-                ]
-            }
-        }
-    }
-)
+
+allowed_imports = dask.config.get("distributed.scheduler.allowed-imports", [])
+allowed_imports += ["dask", "distributed", "dask_awkward"]
+dask.config.set({"distributed.scheduler.allowed-imports": list(set(allowed_imports))})


### PR DESCRIPTION
This new implementation makes sure to conserve all entries in the existing `allowed-imports` configuration option for the distributed scheduler