### PR TITLE
Add more ak verbs

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -670,6 +671,13 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
     if not highlevel:
         raise ValueError("Only highlevel=True is supported")
+
+    warnings.warn(
+        f"""Please ensure that {counts}
+        is partitionwise-compatible with {array}
+        (e.g. counts comes from a dak.num(array, axis=1)),
+        otherwise this unflatten operation will fail when computed!"""
+    )
 
     #  TODO: remove after fixing issue in awkward
     meta = typetracer_from_form(

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -558,7 +558,15 @@ def ones_like(
 
 @borrow_docstring(ak.to_packed)
 def to_packed(array, highlevel=True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
+    return map_partitions(
+        ak.to_packed,
+        array,
+        highlevel=highlevel,
+        behavior=behavior,
+    )
 
 
 class _PadNoneFn:

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -723,7 +723,23 @@ def strings_astype(array, to, highlevel=True, behavior=None):
 
 @borrow_docstring(ak.to_regular)
 def to_regular(array, axis=1, highlevel=True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
+    if axis == 0:
+        raise ValueError("axis must be > 0 for from_regular")
+
+    #  NB: It is impossible to compute the typetracer for this.
+    #      We don't know the output array size in general,
+    #      since it is var.
+    return map_partitions(
+        ak.to_regular,
+        array,
+        axis=axis,
+        highlevel=highlevel,
+        behavior=behavior,
+        label="to-regular",
+    )
 
 
 @borrow_docstring(ak.unflatten)

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -207,10 +207,17 @@ def broadcast_arrays(*arrays, highlevel=True, **kwargs):
     if not highlevel:
         raise ValueError("Only highlevel=True is supported")
 
+    if not compatible_partitions(*arrays):
+        raise IncompatiblePartitions("broadcast_arrays", *arrays)
+
     array_metas = (array._meta for array in arrays)
 
     metas = ak.broadcast_arrays(*array_metas, highlevel=highlevel, **kwargs)
 
+    # here we return the list of broadcasted arrays
+    # it's OK to repeat the work this way since usually
+    # only one of the outputs will be computed, and
+    # broadcast_arrays is fast anyway
     return [
         map_partitions(
             _BroadcastArraysFn(i, highlevel=highlevel, **kwargs),

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -87,7 +87,19 @@ def argcartesian(
     highlevel=True,
     behavior=None,
 ):
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
     if axis == 1:
+        meta = ak.cartesian(
+            [array._meta for array in arrays],
+            axis=axis,
+            nested=nested,
+            parameters=parameters,
+            with_name=with_name,
+            highlevel=highlevel,
+            behavior=behavior,
+        )
         fn = _ArgCartesianFn(
             axis=axis,
             nested=nested,
@@ -96,7 +108,9 @@ def argcartesian(
             highlevel=highlevel,
             behavior=behavior,
         )
-        return map_partitions(fn, *arrays, label="argcartesian", output_divisions=1)
+        return map_partitions(
+            fn, *arrays, label="argcartesian", output_divisions=1, meta=meta
+        )
     raise DaskAwkwardNotImplemented("TODO")
 
 
@@ -122,8 +136,14 @@ def argcombinations(
     highlevel=True,
     behavior=None,
 ):
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
     if fields is not None and len(fields) != n:
         raise ValueError("if provided, the length of 'fields' must be 'n'")
+
+    if axis < 0:
+        raise ValueError("the 'axis' for argcombinations must be non-negative")
 
     if axis != 0:
         fn = _ArgCombinationsFn(

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -652,7 +652,30 @@ def to_regular(array, axis=1, highlevel=True, behavior=None):
 
 @borrow_docstring(ak.unflatten)
 def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
+    #  TODO: remove after fixing issue in awkward
+    meta = typetracer_from_form(
+        ak.unflatten(
+            array._meta.layout.form.length_zero_array(),
+            counts._meta.layout.form.length_zero_array(),
+            axis=axis,
+            highlevel=highlevel,
+            behavior=behavior,
+        ).layout.form
+    )
+
+    return map_partitions(
+        ak.unflatten,
+        array,
+        counts,
+        axis=axis,
+        highlevel=highlevel,
+        behavior=behavior,
+        meta=meta,
+        label="unflatten",
+    )
 
 
 @borrow_docstring(ak.unzip)

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -372,7 +372,20 @@ def flatten(
 
 @borrow_docstring(ak.from_regular)
 def from_regular(array, axis=1, highlevel=True, behavior=None):
-    raise DaskAwkwardNotImplemented("TODO")
+    if not highlevel:
+        raise ValueError("Only highlevel=True is supported")
+
+    if axis == 0:
+        raise ValueError("axis must be > 0 for from_regular")
+
+    return map_partitions(
+        ak.from_regular,
+        array,
+        axis=axis,
+        highlevel=highlevel,
+        behavior=behavior,
+        label="from-regular",
+    )
 
 
 @borrow_docstring(ak.full_like)

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -164,6 +164,14 @@ def argcombinations(
     raise DaskAwkwardNotImplemented("TODO")
 
 
+class _ArgsortFn:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, array):
+        return ak.argsort(array, **self.kwargs)
+
+
 @borrow_docstring(ak.argsort)
 def argsort(
     array,
@@ -173,7 +181,15 @@ def argsort(
     highlevel=True,
     behavior=None,
 ):
-    raise DaskAwkwardNotImplemented("TODO")
+    if axis == 0:
+        raise DaskAwkwardNotImplemented("TODO")
+    fn = _ArgsortFn(
+        axis=axis,
+        ascending=ascending,
+        stable=stable,
+        behavior=behavior,
+    )
+    return map_partitions(fn, array, label="argsort", output_divisions=1)
 
 
 @borrow_docstring(ak.broadcast_arrays)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,17 @@ def L3() -> list[list[dict[str, float]]]:
 
 
 @pytest.fixture(scope="session")
+def L4() -> list[list[dict[str, float]]]:
+    return [
+        [{"x": 1.9, "y": 9.0}, {"x": 2.0, "y": 8.2}, {"x": 9.9, "y": 9.0}],
+        None,
+        [{"x": 1.9, "y": 8.0}, {"x": 4.0, "y": 6.5}],
+        [{"x": 1.9, "y": 7.0}],
+        [{"x": 1.9, "y": 6.0}, {"x": 6.0, "y": 4.8}, {"x": 9.9, "y": 9.0}],
+    ]
+
+
+@pytest.fixture(scope="session")
 def caa_parquet(caa: ak.Array, tmpdir_factory: pytest.TempdirFactory) -> str:
     fname = tmpdir_factory.mktemp("parquet_data") / "caa.parquet"  # type: ignore
     ak.to_parquet(caa, str(fname), extensionarray=False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import awkward as ak
-import dask.config
 import fsspec
 import numpy as np
 import pytest

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -251,6 +251,14 @@ def test_singletons(L4):
 
 
 @pytest.mark.parametrize("ascending", [True, False])
+def test_argsort(daa, caa, ascending):
+    assert_eq(
+        dak.argsort(daa.points.x, ascending=ascending),
+        ak.argsort(caa.points.x, ascending=ascending),
+    )
+
+
+@pytest.mark.parametrize("ascending", [True, False])
 def test_sort(daa, caa, ascending):
     assert_eq(
         dak.sort(daa.points.x, ascending=ascending),

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -365,3 +365,16 @@ def test_to_regular(caa):
         dak.to_regular(dregular, axis=1),
         ak.to_regular(regular, axis=1),
     )
+
+
+def test_broadcast_arrays(daa, caa):
+    flat = ak.Array([1] * 15)
+    dflat = dak.from_awkward(flat, 3)
+
+    dak_broadcast = dak.broadcast_arrays(dflat, daa.points.x)
+    ak_broadcast = ak.broadcast_arrays(flat, caa.points.x)
+
+    assert len(dak_broadcast) == len(ak_broadcast)
+
+    for db, b in zip(dak_broadcast, ak_broadcast):
+        assert_eq(db, b)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -103,6 +103,17 @@ def test_cartesian(caa: ak.Array, daa: dak.Array) -> None:
     assert_eq(dz, cz)
 
 
+def test_argcartesian(caa: ak.Array, daa: dak.Array) -> None:
+    da1 = daa["points", "x"]
+    da2 = daa["points", "y"]
+    ca1 = caa["points", "x"]
+    ca2 = caa["points", "y"]
+
+    dz = dak.argcartesian([da1, da2], axis=1)
+    cz = ak.argcartesian([ca1, ca2], axis=1)
+    assert_eq(dz, cz)
+
+
 def test_ones_like(caa: ak.Array, daa: dak.Array) -> None:
     da1 = dak.ones_like(daa.points.x)
     ca1 = ak.ones_like(caa["points", "x"])
@@ -188,6 +199,26 @@ def test_combinations(caa, daa, axis, fields):
 def test_combinations_raise(daa):
     with pytest.raises(ValueError, match="if provided, the length"):
         dak.combinations(daa, 2, fields=["a", "b", "c"])
+
+
+@pytest.mark.parametrize("axis", [1, -1])
+@pytest.mark.parametrize("fields", [None, ["a", "b"]])
+def test_argcombinations(caa, daa, axis, fields):
+    if axis < 0:
+        with pytest.raises(
+            ValueError, match="the 'axis' for argcombinations must be non-negative"
+        ):
+            dak.argcombinations(daa, 2, axis=axis)
+    else:
+        assert_eq(
+            dak.argcombinations(daa, 2, axis=axis),
+            ak.argcombinations(caa, 2, axis=axis),
+        )
+
+
+def test_argcombinations_raise(daa):
+    with pytest.raises(ValueError, match="if provided, the length"):
+        dak.argcombinations(daa, 2, fields=["a", "b", "c"])
 
 
 @pytest.mark.parametrize("mergebool", [True, False])

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -316,3 +316,10 @@ def test_unflatten(daa, caa):
         dak.unflatten(daa, dcounts),
         ak.unflatten(caa, counts),
     )
+
+
+def test_to_packed(daa, caa):
+    assert_eq(
+        dak.to_packed(daa),
+        ak.to_packed(caa),
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import awkward as ak
+import numpy as np
 import pytest
 
 import dask_awkward as dak
@@ -254,4 +255,46 @@ def test_sort(daa, caa, ascending):
     assert_eq(
         dak.sort(daa.points.x, ascending=ascending),
         ak.sort(caa.points.x, ascending=ascending),
+    )
+
+
+def test_copy(daa):
+    with pytest.raises(
+        DaskAwkwardNotImplemented,
+        match="This function is not necessary in the context of dask-awkward.",
+    ):
+        dak.copy(daa)
+
+
+@pytest.mark.parametrize(
+    "thedtype",
+    [
+        bool,
+        np.int8,
+        np.uint8,
+        np.int16,
+        np.uint16,
+        np.int32,
+        np.uint32,
+        np.int64,
+        np.uint64,
+        np.float32,
+        np.float64,
+        np.complex64,
+        np.complex128,
+        np.datetime64,
+        np.timedelta64,
+        np.float16,
+    ],
+)
+def test_full_like(daa, caa, thedtype):
+    value = 12.6
+    if thedtype is np.datetime64:
+        value = thedtype(int(12.6), "us")
+    elif thedtype is np.timedelta64:
+        value = thedtype(int(12.6))
+
+    assert_eq(
+        dak.full_like(daa, value, dtype=thedtype),
+        ak.full_like(caa, value, dtype=thedtype),
     )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -298,3 +298,13 @@ def test_full_like(daa, caa, thedtype):
         dak.full_like(daa, value, dtype=thedtype),
         ak.full_like(caa, value, dtype=thedtype),
     )
+
+
+def test_unflatten(daa, caa):
+    counts = ak.Array([2, 3, 0, 5, 3, 2])
+    dcounts = dak.from_awkward(counts, daa.npartitions)
+
+    assert_eq(
+        dak.unflatten(daa, dcounts),
+        ak.unflatten(caa, counts),
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -323,3 +323,22 @@ def test_to_packed(daa, caa):
         dak.to_packed(daa),
         ak.to_packed(caa),
     )
+
+
+def test_ravel(daa, caa):
+    assert_eq(
+        dak.ravel(daa.points.x),
+        ak.ravel(caa.points.x),
+    )
+
+
+@pytest.mark.xfail
+def test_ravel_fail(daa, caa):
+    assert_eq(
+        dak.ravel(daa),
+        ak.ravel(caa),
+    )
+
+
+def test_run_lengths(daa, caa):
+    assert_eq(dak.run_lengths(daa.points.x), ak.run_lengths(caa.points.x))

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -341,4 +341,17 @@ def test_ravel_fail(daa, caa):
 
 
 def test_run_lengths(daa, caa):
-    assert_eq(dak.run_lengths(daa.points.x), ak.run_lengths(caa.points.x))
+    assert_eq(
+        dak.run_lengths(daa.points.x),
+        ak.run_lengths(caa.points.x),
+    )
+
+
+def test_from_regular(caa):
+    regular = ak.to_regular(ak.to_packed(caa[[0, 4, 5, 9, 10, 14]].points.x))
+    dregular = dak.from_awkward(regular, 3)
+
+    assert_eq(
+        dak.from_regular(dregular, axis=1),
+        ak.from_regular(regular, axis=1),
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -355,3 +355,13 @@ def test_from_regular(caa):
         dak.from_regular(dregular, axis=1),
         ak.from_regular(regular, axis=1),
     )
+
+
+def test_to_regular(caa):
+    regular = ak.to_packed(caa[[0, 4, 5, 9, 10, 14]].points.x)
+    dregular = dak.from_awkward(regular, 3)
+
+    assert_eq(
+        dak.to_regular(dregular, axis=1),
+        ak.to_regular(regular, axis=1),
+    )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -231,3 +231,27 @@ def test_where(caa, daa, mergebool):
             caa.points.x > caa.points.y, caa.points.x, caa.points.y, mergebool=mergebool
         ),
     )
+
+
+def test_isclose(daa, caa):
+    assert_eq(
+        dak.isclose(daa.points.x, daa.points.y),
+        ak.isclose(caa.points.x, caa.points.y),
+    )
+
+
+def test_singletons(L4):
+    caa = ak.Array(L4)
+    daa = dak.from_awkward(caa, 1)
+    assert_eq(
+        dak.singletons(daa),
+        ak.singletons(caa),
+    )
+
+
+@pytest.mark.parametrize("ascending", [True, False])
+def test_sort(daa, caa, ascending):
+    assert_eq(
+        dak.sort(daa.points.x, ascending=ascending),
+        ak.sort(caa.points.x, ascending=ascending),
+    )


### PR DESCRIPTION
Fixes #124
Fixes #128

add:
- argcartesian
- argcombinations
- isclose
- singletons
- argsort (for axis > 0, from #130)
- sort (for axis > 0)
- appropriate error for copy
- full_like (needs issue on awkward opened for meta calculation)
- unflatten (currently simplistic implementation, needs work to be general since it requires repartitioning, but very important/necessary)
- to_packed
- ravel (with warnings about recordarrays)
- run_lengths (with warning about axis=0)
- from_regular
- to_regular
- broadcast_arrays (#128)

remove:
- concatenate impl in `structure.py`