### PR TITLE
Adjust `_meta` determination during graph construction (new config parameter, length zero array fallback)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "awkward >=2.0.7",
+    "awkward >=2.0.8",
     "dask >=2022.02.1",
 ]
 dynamic = ["version"]

--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -1,5 +1,9 @@
 awkward:
 
+  # This option causes graph creation to fail if the metadata of a
+  # dask-awkward Array collection cannot be determined.
+  raise-failed-meta: False
+
   # This option is for cases where new array collections are created
   # with unknown metadata. The default setting is to compute the first
   # partition of the collection so that we can define the metadata. If

--- a/src/dask_awkward/config.py
+++ b/src/dask_awkward/config.py
@@ -11,6 +11,6 @@ with open(fn) as f:
 
 dask.config.update_defaults(defaults)
 
-allowed_imports = dask.config.get("distributed.scheduler.allowed-imports", [])
+allowed_imports = dask.config.get("distributed.scheduler.allowed-imports", default=[])
 allowed_imports += ["dask", "distributed", "dask_awkward"]
 dask.config.set({"distributed.scheduler.allowed-imports": list(set(allowed_imports))})

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1607,7 +1607,7 @@ def map_meta(fn: Callable, *args: Any, **kwargs: Any) -> ak.Array | None:
         lzas = to_length_zero_arrays(args)
         meta = typetracer_from_form(fn(*lzas, **kwargs).layout.form)
         return meta
-    except Exception as err:
+    except Exception:
         # if compute-unknown-meta is True and we've gotten to this
         # point, we want to throw a warning because a compute is going
         # to happen as a consequence of us not being able to determine

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import keyword
 import logging
 import operator
-import os
 import sys
 import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -67,7 +67,6 @@ def test_single_ellipsis(daa: dak.Array, caa: ak.Array) -> None:
     assert_eq(daa[...], caa[...])
 
 
-@pytest.mark.xfail(reason="cannot interpret unknown lengths error")
 def test_empty_slice(daa: dak.Array, caa: ak.Array) -> None:
     assert_eq(daa[:], caa[:])
     assert_eq(daa[:, "points"], caa[:, "points"])


### PR DESCRIPTION
This PR changes the way metadata is handled at graph creation time.

1. We've added a configuration parameter `awkward.raise-failed-meta` that, when `True` (default is `False`), will raise an exception during graph creation time if the process of determining a new metadata (typetracer array) fails. For example, in `map_partitions(fn, array)` we always call `fn(array._meta)` to determine the "new" meta on the graph. By default, if this fails we will compute the first partition and issue a warning. The new configuration option will hard fail instead of warning.
2. We've added an additional code path for determining the new meta via a call on a length zero array _instead_ of a high level typetracer array. (the default behavior is to always try on a high level typetracer array). If the new config parameter from (1) is set to `True`, we will never reach this code; but, if we don't want to hard fail after `fn(array._meta)` fails, then we go to the length zero array workaround; which is `fn(array._meta.layout.form.length_zero_array())`. If the later call fails as well, then we issue a warning and fall back to computing the first partition.