### PR TITLE
Only use dask collections to determine divisions/partitions

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1309,7 +1309,7 @@ def map_partitions(
             new_divisions = deps[0].divisions
         else:
             new_divisions = tuple(
-                map(lambda x: x * output_divisions, args[0].divisions)
+                map(lambda x: x * output_divisions, deps[0].divisions)
             )
         return new_array_object(
             hlg,

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1306,7 +1306,7 @@ def map_partitions(
 
     if output_divisions is not None:
         if output_divisions == 1:
-            new_divisions = args[0].divisions
+            new_divisions = deps[0].divisions
         else:
             new_divisions = tuple(
                 map(lambda x: x * output_divisions, args[0].divisions)
@@ -1322,7 +1322,7 @@ def map_partitions(
             hlg,
             name=name,
             meta=meta,
-            npartitions=args[0].npartitions,
+            npartitions=deps[0].npartitions,
         )
 
 


### PR DESCRIPTION
Use deps instead of args since expressions like `1-x` doesn't have a dask collection for `arg[0]`.