### PR TITLE
Fix layer order assumption in optimization

### DIFF
--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -229,7 +229,7 @@ def _get_column_reports(dsk: HighLevelGraph) -> dict[str, Any]:
         layers[name] = _touch_and_call(layers[name])
 
     hlg = HighLevelGraph(layers, deps)
-    outlayer = list(hlg.layers.values())[-1]
+    outlayer = hlg.layers[hlg._toposort_layers()[-1]]
 
     try:
         out = get_sync(hlg, list(outlayer.keys())[0])


### PR DESCRIPTION
fixes #172

the optimization always touches all fields in an array if it's the last array in a task graph. we were making an incorrect assumption about the output layer always being the last in the list of layer dictionary values. this PR makes use of the HLG topologically sorted layers method