### PR TITLE
Add ability to have file prefix in to_parquet

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -285,9 +285,9 @@ def to_dask_array(
         dtype = dtype or primitive_to_dtype(array._meta.layout.form.type.primitive)
         if array.known_divisions:
             divs = np.array(array.divisions)
-            chunks = (tuple(divs[1:] - divs[:-1]),)
+            chunks: tuple[tuple[float, ...], ...] = (tuple(divs[1:] - divs[:-1]),)
         else:
-            chunks: tuple[tuple[float, ...], ...] = ((np.nan,) * array.npartitions,)
+            chunks = ((np.nan,) * array.npartitions,)
         return new_da_object(
             graph,
             new.name,


### PR DESCRIPTION
@lgray is this what you had in mind?

```python
to_parquet(a, "/output/path", prefix="abc")
```
will write files of the form (50 partitions):
```
/output/path/abc-part00.parquet
...
/output/path/abc-part49.parquet
```

while
```python
to_parquet(a, "/output/path")
```
remains
```
/output/path/part00.parquet
...
/output/path/part49.parquet
```

(took the opportunity to add a bit of typing to this PR as well)