### PR TITLE
Recurse through nested contents for arrays used in `getitem`

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -872,10 +872,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             return self._getitem_outer_int(where)
 
         elif isinstance(where, Array):
-            try:
-                dtype = where.layout.dtype.type
-            except AttributeError:
-                dtype = where.layout.content.dtype.type
+            layout = where.layout
+            while not hasattr(layout, "dtype"):
+                layout = layout.content
+            dtype = layout.dtype.type
             if issubclass(dtype, (np.bool_, bool, np.int64, np.int32, int)):
                 return self._getitem_outer_bool_or_int_lazy_array(where)
 

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -125,3 +125,10 @@ def test_record_getitem_scalar_results(daa: dak.Array, caa: ak.Array) -> None:
 
 def test_single_partition(daa: dak.Array, caa: ak.Array) -> None:
     assert_eq(daa["points"]["x"][-1][3:], caa["points"]["x"][-1][3:])
+
+
+def test_boolean_array_from_concatenated(daa: dak.Array) -> None:
+    caa = daa.compute()
+    d_concat = dak.concatenate([daa.points, daa.points], axis=1)
+    c_concat = ak.concatenate([caa.points, caa.points], axis=1)
+    assert_eq(d_concat[d_concat.x > 2], c_concat[c_concat.x > 2])


### PR DESCRIPTION
Resolves #188.

I don't know if there's a preferred way to handle this, but this was the solution that I found. I believe the `contents` nesting can be arbitrarily deep, so I think there has to be a loop over them, unless there's an `awkward` shortcut that I'm not aware of.