### PR TITLE
feat: `__setitem__` by way of using dak.with_field

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -516,9 +516,15 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     __dask_scheduler__ = staticmethod(threaded_get)
 
-    def __setitem__(self, where, what):
+    def __setitem__(self, where: str, what: Any) -> None:
+        if not (
+            isinstance(where, str)
+            or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
+        ):
+            TypeError("only fields may be assigned in-place (by field name)")
+
         if not isinstance(what, Array):
-            raise ValueError(
+            raise DaskAwkwardNotImplemented(
                 "Supplying anything other than a dak.Array to __setitem__ is not yet available!"
             )
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -528,7 +528,6 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
         self._meta = appended._meta
         self._dask = appended._dask
-self._name = appended._name
         self._name = appended._name
         print(ak.fields(self._meta))
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -529,6 +529,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         self._meta = appended._meta
         self._dask = appended._dask
 self._name = appended._name
+        self._name = appended._name
         print(ak.fields(self._meta))
 
     def _rebuild(

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -516,6 +516,21 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     __dask_scheduler__ = staticmethod(threaded_get)
 
+    def __setitem__(self, where, what):
+        if not isinstance(what, Array):
+            raise ValueError(
+                "Supplying anything other than a dak.Array to __setitem__ is not yet available!"
+            )
+
+        from dask_awkward.lib.structure import with_field
+
+        appended = with_field(self, what, where=where, behavior=self.behavior)
+
+        self._meta = appended._meta
+        self._dask = appended._dask
+
+        print(ak.fields(self._meta))
+
     def _rebuild(
         self,
         dsk: HighLevelGraph,

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -528,7 +528,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
         self._meta = appended._meta
         self._dask = appended._dask
-
+self._name = appended._name
         print(ak.fields(self._meta))
 
     def _rebuild(

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -529,7 +529,6 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         self._meta = appended._meta
         self._dask = appended._dask
         self._name = appended._name
-        print(ak.fields(self._meta))
 
     def _rebuild(
         self,

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -172,6 +172,8 @@ def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
     daa["xx"] = daa["points"]["x"]
     caa["xx"] = caa["points"]["x"]
 
+    daa["points", "z"] = np.sqrt(daa.points.x**2 + daa.points.y**2)
+    caa["points", "z"] = np.sqrt(caa.points.x**2 + caa.points.y**2)
     assert_eq(caa, daa)
 
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -172,7 +172,7 @@ def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
     daa["xx"] = daa["points"]["x"]
     caa["xx"] = caa["points"]["x"]
 
-    assert_eq(caa["xx"], daa["xx"])
+    assert_eq(caa, daa)
 
 
 def test_with_parameter() -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -168,6 +168,21 @@ def test_with_field(caa: ak.Array, daa: dak.Array) -> None:
     )
 
 
+def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
+    daa["xx"] = daa["points"]["x"]
+    caa["xx"] = caa["points"]["x"]
+
+    print(ak.fields(caa), dak.fields(daa))
+
+    print(daa["xx"])
+
+    print(caa["xx"])
+
+    print(daa["xx"].compute())
+
+    assert_eq(caa["xx"], daa["xx"])
+
+
 def test_with_parameter() -> None:
     a = [[1, 2, 3], [], [4]]
     b = [[], [3], []]

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -172,14 +172,6 @@ def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
     daa["xx"] = daa["points"]["x"]
     caa["xx"] = caa["points"]["x"]
 
-    print(ak.fields(caa), dak.fields(daa))
-
-    print(daa["xx"])
-
-    print(caa["xx"])
-
-    print(daa["xx"].compute())
-
     assert_eq(caa["xx"], daa["xx"])
 
 


### PR DESCRIPTION
Restore expected behavior from awkward arrays, namely being able to set record-array fields via `__setitem__`.

Doesn't work yet - help or tips appreciated :-)