### PR TITLE
Use inspect to determine if we're passing in additional array contexts.

### DIFF
--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import awkward as ak
 import numpy as np
 import pytest
@@ -12,22 +10,9 @@ from dask_awkward.lib.testutils import assert_eq
 behaviors: dict = {}
 
 
-class _ClassMethodFn:
-    def __init__(self, attr: str, **kwargs: Any) -> None:
-        self.attr = attr
-
-    def __call__(self, coll: ak.Array, *args: Any, **kwargs: Any) -> ak.Array:
-        return getattr(coll, self.attr)(*args, **kwargs)
-
-
 @ak.mixin_class(behaviors)
 class Point:
-    def distance(self, other, __dask_array__=None):
-        if __dask_array__ is not None:
-            return __dask_array__.map_partitions(
-                _ClassMethodFn("distance"),
-                other,
-            )
+    def distance(self, other):
         return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
 
     @property
@@ -35,11 +20,7 @@ class Point:
         return self.x * self.x
 
     @ak.mixin_class_method(np.abs)
-    def point_abs(self, __dask_array__=None):
-        if __dask_array__ is not None:
-            return __dask_array__.map_partitions(
-                _ClassMethodFn("point_abs"),
-            )
+    def point_abs(self):
         return np.sqrt(self.x**2 + self.y**2)
 
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -5,7 +5,6 @@ import pytest
 distributed = pytest.importorskip("distributed")
 
 from pathlib import Path
-from typing import Any
 
 import awkward as ak
 import numpy as np
@@ -87,22 +86,9 @@ def test_from_delayed(loop, ndjson_points_file):  # noqa
 behaviors: dict = {}
 
 
-class _ClassMethodFn:
-    def __init__(self, attr: str, **kwargs: Any) -> None:
-        self.attr = attr
-
-    def __call__(self, coll: ak.Array, *args: Any, **kwargs: Any) -> ak.Array:
-        return getattr(coll, self.attr)(*args, **kwargs)
-
-
 @ak.mixin_class(behaviors)
 class Point:
-    def distance(self, other, __dask_array__=None):
-        if __dask_array__ is not None:
-            return __dask_array__.map_partitions(
-                _ClassMethodFn("distance"),
-                other,
-            )
+    def distance(self, other):
         return np.sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2)
 
     @property
@@ -110,11 +96,7 @@ class Point:
         return self.x * self.x
 
     @ak.mixin_class_method(np.abs)
-    def point_abs(self, __dask_array__=None):
-        if __dask_array__ is not None:
-            return __dask_array__.map_partitions(
-                _ClassMethodFn("point_abs"),
-            )
+    def point_abs(self):
         return np.sqrt(self.x**2 + self.y**2)
 
 


### PR DESCRIPTION
For methods we check for `__dunder__` parameters in the function signature.

For properties we check for the existence of a single additional parameter which *is* the array context `self`.

Fixes #193 

Also fixes a possible bug in `__setitem__` where it wouldn't raise if you assigned to some random thing.