### PR TITLE
feat: added an unproject_layout function

### DIFF
--- a/src/dask_awkward/unproject_layout.py
+++ b/src/dask_awkward/unproject_layout.py
@@ -1,0 +1,362 @@
+import math
+
+import numpy as np
+
+import awkward as ak
+from awkward._nplikes import nplike_of
+from awkward.forms import (
+    Form,
+    EmptyForm,
+    NumpyForm,
+    BitMaskedForm,
+    ByteMaskedForm,
+    IndexedForm,
+    IndexedOptionForm,
+    ListForm,
+    ListOffsetForm,
+    RegularForm,
+    UnmaskedForm,
+    RecordForm,
+    UnionForm,
+)
+from awkward.contents import (
+    Content,
+    EmptyArray,
+    NumpyArray,
+    BitMaskedArray,
+    ByteMaskedArray,
+    IndexedArray,
+    IndexedOptionArray,
+    ListArray,
+    ListOffsetArray,
+    RegularArray,
+    UnmaskedArray,
+    RecordArray,
+    UnionArray,
+)
+
+
+class DummyIndex:
+    def __init__(self, length, nplike):
+        self._length = length
+        self._nplike = nplike
+
+    def __len__(self):
+        return self._length
+
+    @property
+    def length(self):
+        return self._length
+
+
+class DummyIndex8(DummyIndex, ak.index.Index8):
+    @property
+    def dtype(self):
+        return np.dtype(np.int8)
+
+
+class DummyIndexU8(DummyIndex, ak.index.Index8):
+    @property
+    def dtype(self):
+        return np.dtype(np.uint8)
+
+
+class DummyIndex32(DummyIndex, ak.index.Index8):
+    @property
+    def dtype(self):
+        return np.dtype(np.int32)
+
+
+class DummyIndexU32(DummyIndex, ak.index.Index8):
+    @property
+    def dtype(self):
+        return np.dtype(np.uint32)
+
+
+class DummyIndex64(DummyIndex, ak.index.Index8):
+    @property
+    def dtype(self):
+        return np.dtype(np.int64)
+
+
+index_of = {
+    "i8": DummyIndex8,
+    "u8": DummyIndexU8,
+    "i32": DummyIndex32,
+    "u32": DummyIndexU32,
+    "i64": DummyIndex64,
+}
+dtype_of = {
+    "i32": np.int32,
+    "u32": np.uint32,
+    "i64": np.int64,
+}
+
+
+def dummy_buffer(shape, dtype, nplike):
+    return nplike.broadcast_to(nplike.asarray([0], dtype=dtype), shape)
+
+
+def compatible(form: Form, layout: Content) -> bool:
+    if layout is None:
+        return True
+
+    elif isinstance(layout, Content) and type(form) is layout.form_cls:
+        if isinstance(form, (EmptyForm, NumpyForm)):
+            # 0 contents
+            return True
+
+        elif isinstance(
+            form,
+            (
+                BitMaskedForm,
+                ByteMaskedForm,
+                IndexedForm,
+                IndexedOptionForm,
+                ListForm,
+                ListOffsetForm,
+                RegularForm,
+                UnmaskedForm,
+            ),
+        ):
+            # 1 content
+            return compatible(form.content, layout.content)
+
+        elif isinstance(form, RecordForm):
+            # arbitrarily many contents, possibly with missing fields
+            for field in form.fields:
+                if layout.has_field(field):
+                    if not compatible(form.content(field), layout.content(field)):
+                        return False
+            return True
+
+        elif isinstance(form, UnionForm):
+            # arbitrarily many contents, possibly with missing fields
+            for sublayout in layout.contents:
+                if not any(compatible(subform, sublayout) for subform in form.contents):
+                    return False
+            return True
+
+    elif isinstance(form, UnionForm):
+        for subform in form.contents:
+            if compatible(subform, layout):
+                return True
+        else:
+            return False
+
+    # handle other cases that come up here...
+
+    else:
+        return False
+
+
+def _unproject_layout(form, layout, length, nplike):
+    if layout is None:
+        # construct the "minimum necessary" layout
+        # maintaining length constraints if there are any, 0 otherwise
+
+        if isinstance(form, EmptyForm):
+            return EmptyArray(parameters=form.parameters)
+
+        elif isinstance(form, NumpyForm):
+            return NumpyArray(
+                dummy_buffer(
+                    (length,) + form.inner_shape,
+                    ak.types.numpytype.primitive_to_dtype(form.primitive),
+                    nplike,
+                ),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, BitMaskedForm):
+            return BitMaskedArray(
+                index_of[form.mask](int(math.ceil(length / 8.0)), nplike),
+                _unproject_layout(form.content, None, length, nplike),
+                form.valid_when,
+                length,
+                form.lsb_order,
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, ByteMaskedForm):
+            return ByteMaskedArray(
+                index_of[form.mask](length, nplike),
+                _unproject_layout(form.content, None, length, nplike),
+                form.valid_when,
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, IndexedForm):
+            return IndexedArray(
+                index_of[form.index](length, nplike),
+                _unproject_layout(form.content, None, 0, nplike),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, IndexedOptionForm):
+            return IndexedOptionArray(
+                index_of[form.index](length, nplike),
+                _unproject_layout(form.content, None, 0, nplike),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, ListForm):
+            return ListArray(
+                index_of[form.starts](length, nplike),
+                index_of[form.stops](length, nplike),
+                _unproject_layout(form.content, None, 0, nplike),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, ListOffsetForm):
+            return ListOffsetArray(
+                index_of[form.offsets](length + 1, nplike),
+                _unproject_layout(form.content, None, 0, nplike),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, RegularForm):
+            return RegularArray(
+                _unproject_layout(form.content, None, length * form.size, nplike),
+                form.size,
+                length,
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, UnmaskedForm):
+            return UnmaskedArray(
+                _unproject_layout(form.content, None, length, nplike),
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, RecordForm):
+            return RecordArray(
+                [
+                    _unproject_layout(content, None, length, nplike)
+                    for content in form.contents
+                ],
+                None if form.is_tuple else form.fields,
+                length,
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, UnionForm):
+            return UnionArray(
+                index_of[form.tags](length, nplike),
+                index_of[form.index](length, nplike),
+                [
+                    _unproject_layout(content, None, 0, nplike)
+                    for content in form.contents
+                ],
+                parameters=form.parameters,
+            )
+
+        else:
+            raise AssertionError(f"unrecognized Form type: {type(form)}")
+
+    elif isinstance(layout, Content) and type(form) is layout.form_cls:
+        # pass on this layout node, allowing for descendants to be missing
+
+        if isinstance(form, (EmptyForm, NumpyForm)):
+            # 0 contents
+            return layout
+
+        elif isinstance(
+            form,
+            (
+                BitMaskedForm,
+                ByteMaskedForm,
+                IndexedForm,
+                IndexedOptionForm,
+                ListForm,
+                ListOffsetForm,
+                RegularForm,
+                UnmaskedForm,
+            ),
+        ):
+            # 1 content
+            return layout.copy(
+                content=_unproject_layout(
+                    form.content, layout.content, layout.content.length, nplike
+                )
+            )
+
+        elif isinstance(form, RecordForm):
+            # arbitrarily many contents, possibly with missing fields
+            contents = []
+            for field in form.fields:
+                if layout.has_field(field):
+                    layout_content = layout.content(field)
+                    contents.append(
+                        _unproject_layout(
+                            form.content(field),
+                            layout_content,
+                            layout_content.length,
+                            nplike,
+                        )
+                    )
+                else:
+                    contents.append(
+                        _unproject_layout(form.content(field), None, length, nplike)
+                    )
+
+            return RecordArray(
+                contents,
+                None if form.is_tuple else form.fields,
+                length,
+                parameters=form.parameters,
+            )
+
+        elif isinstance(form, UnionForm):
+            # arbitrarily many contents, possibly with missing fields
+            available = dict(enumerate(layout.contents))
+
+            newtags = nplike.empty_like(layout.tags.data)
+            contents = []
+            for newtag, subform in enumerate(form.contents):
+                for oldtag, sublayout in available.items():
+                    if compatible(subform, sublayout):
+                        contents.append(sublayout)
+                        newtags[layout.tags.data == oldtag] = newtag
+                        del available[oldtag]
+                        break
+                else:
+                    contents.append(_unproject_layout(subform, None, 0, nplike))
+
+            return UnionArray(
+                ak.index.Index8(newtags),
+                layout.index,
+                contents,
+                parameters=form.parameters,
+            )
+
+        else:
+            raise AssertionError(f"unrecognized Form type: {type(form)}")
+
+    elif isinstance(form, UnionForm):
+        newtags, newindex = None, None
+        contents = []
+        for newtag, subform in enumerate(form.contents):
+            if compatible(subform, layout):
+                contents.append(layout)
+                newtags = nplike.full(layout.length, newtag, dtype=np.int8)
+                newindex = nplike.arange(layout.length, dtype=dtype_of[form.index])
+            else:
+                contents.append(_unproject_layout(subform, None, 0, nplike))
+
+        assert newtags is not None and newindex is not None
+        return UnionArray(
+            ak.index.Index8(newtags),
+            ak.index.Index(newindex),
+            contents,
+            parameters=form.parameters,
+        )
+
+    # handle other cases that come up here...
+
+    else:
+        raise AssertionError(f"unexpected combination: {type(form)} and {type(layout)}")
+
+
+def unproject_layout(form: Form, layout: Content) -> Content:
+    return _unproject_layout(form, layout, layout.length, nplike_of(layout))

--- a/src/dask_awkward/unproject_layout.py
+++ b/src/dask_awkward/unproject_layout.py
@@ -1,38 +1,37 @@
 import math
 
-import numpy as np
-
 import awkward as ak
+import numpy as np
 from awkward._nplikes import nplike_of
-from awkward.forms import (
-    Form,
-    EmptyForm,
-    NumpyForm,
-    BitMaskedForm,
-    ByteMaskedForm,
-    IndexedForm,
-    IndexedOptionForm,
-    ListForm,
-    ListOffsetForm,
-    RegularForm,
-    UnmaskedForm,
-    RecordForm,
-    UnionForm,
-)
 from awkward.contents import (
-    Content,
-    EmptyArray,
-    NumpyArray,
     BitMaskedArray,
     ByteMaskedArray,
+    Content,
+    EmptyArray,
     IndexedArray,
     IndexedOptionArray,
     ListArray,
     ListOffsetArray,
-    RegularArray,
-    UnmaskedArray,
+    NumpyArray,
     RecordArray,
+    RegularArray,
     UnionArray,
+    UnmaskedArray,
+)
+from awkward.forms import (
+    BitMaskedForm,
+    ByteMaskedForm,
+    EmptyForm,
+    Form,
+    IndexedForm,
+    IndexedOptionForm,
+    ListForm,
+    ListOffsetForm,
+    NumpyForm,
+    RecordForm,
+    RegularForm,
+    UnionForm,
+    UnmaskedForm,
 )
 
 

--- a/tests/test_unproject_layout.py
+++ b/tests/test_unproject_layout.py
@@ -1,0 +1,89 @@
+import awkward as ak
+
+from dask_awkward.unproject_layout import unproject_layout
+
+
+def _compare_values(index, projected, x, unprojected):
+    if isinstance(x, list):
+        for i, xi in enumerate(x):
+            _compare_values(index + (i,), projected, xi, unprojected)
+
+    elif isinstance(x, dict):
+        for f, xf in x.items():
+            _compare_values(index + (f,), projected, xf, unprojected)
+
+    else:
+        assert x == unprojected[index], f"{projected}\n\nat {index}"
+
+
+def compare_values(projected, unprojected):
+    p = ak.to_list(projected)
+    _compare_values((), p, p, unprojected)
+
+
+def test_EmptyArray():
+    form = ak.contents.RecordArray(
+        [ak.from_iter([], highlevel=False), ak.from_iter([], highlevel=False)],
+        ["x", "y"],
+        0,
+    ).form
+    projected = ak.contents.RecordArray(
+        [ak.from_iter([], highlevel=False)],
+        ["x"],
+        0,
+    )
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)
+
+
+def test_NumpyArray():
+    form = ak.from_iter(
+        [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}, {"x": 3, "y": 3.3}], highlevel=False
+    ).form
+    projected = ak.from_iter([{"x": 1}, {"x": 2}, {"x": 3}], highlevel=False)
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)
+
+
+def test_ListOffsetArray():
+    form = ak.from_iter(
+        [{"x": 1, "y": []}, {"x": 2, "y": [1]}, {"x": 3, "y": [1, 2]}], highlevel=False
+    ).form
+    projected = ak.from_iter([{"x": 1}, {"x": 2}, {"x": 3}], highlevel=False)
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)
+
+
+def test_string():
+    form = ak.from_iter(
+        [{"x": 1, "y": "one"}, {"x": 2, "y": "two"}, {"x": 3, "y": "three"}],
+        highlevel=False,
+    ).form
+    projected = ak.from_iter([{"x": 1}, {"x": 2}, {"x": 3}], highlevel=False)
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)
+
+
+def test_RecordArray():
+    form = ak.from_iter(
+        [
+            {"in": {"x": 1, "y": []}},
+            {"in": {"x": 2, "y": [1]}},
+            {"in": {"x": 3, "y": [1, 2]}},
+        ],
+        highlevel=False,
+    ).form
+    projected = ak.from_iter(
+        [{"in": {"x": 1}}, {"in": {"x": 2}}, {"in": {"x": 3}}], highlevel=False
+    )
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)
+
+
+def test_UnionArray():
+    form = ak.from_iter(
+        [{"x": 1, "y": 1}, {"x": 2, "y": "two"}, {"x": 3, "y": 3}], highlevel=False
+    ).form
+    projected = ak.from_iter([{"x": 1}, {"x": 2}, {"x": 3}], highlevel=False)
+    unprojected = unproject_layout(form, projected)
+    compare_values(projected, unprojected)


### PR DESCRIPTION
This is 99% of an `unproject_layout` function. The only public function in this new file is

```python
def unproject_layout(form: Form, layout: Content) -> Content
```

where the `form` is the "original Form," the structure of what you want this function to return as an array (low-level `Content`), and `layout` is the "projected array," which has a subset of the fields of the "original Form."

You can also verify (by assertion) that they are

```python
def compatible(form: Form, layout: Content) -> bool
```

before running the recursive function (`_unproject_layout`).

@agoose77 and I were talking about this after the dask-awkward meeting. The difficult part to handle is the union type, as well as interactions between the union type and an option type. When constructing the projected array, unnecessary unions get simplified (they _have_ to, because of some rules we're established), so that part of the projected array can have different `Content` nodes than the corresponding `Form` nodes in the "original Form." When we fully handle that, it will probably only be a few special cases (no more than 3, I'm guessing). That's what the

```python
# handle other cases that come up here...
```

is; we expect to have to handle some cases in which the `Form` class doesn't exactly correspond to the `Content` class.

The test function tests _a few_ cases, but that gets us past the obvious bugs. It will be easier to test thoroughly in the context of the full Dask machinery, since that provides the projected arrays in a way that I don't have to build manually. Once you've hooked this up, I can get a full suite of Awkward structures that we can run through, you provide the projections, and then we handle the special cases as we encounter them.

--------------

There is not very much of this that is duplicated from `ak.from_buffers`; only passing down the predicted `length` through the recursion, and even that is simplified in this case. It makes a lot more sense as a specialized function than trying to shoehorn it into `ak.from_buffers`.