### PR TITLE
DOC: quotes around .[complete]

### DIFF
--- a/docs/dev-contributing.rst
+++ b/docs/dev-contributing.rst
@@ -21,7 +21,7 @@ branch:
    $ git clone <url to your fork>
    $ cd dask-awkward
    $ git remote add upstream https://github.com/dask-contrib/dask-awkward
-   $ pip install -e .[complete]
+   $ pip install -e ".[complete]"
    $ git checkout -b name-your-branch upstream/mean
 
 Make your changes and be sure to add a test. Run ``pytest`` in the


### PR DESCRIPTION
This may only be an issue when using macs.

Without the "" I get zsh: no matches found: .[complete]