### PR TITLE
fix: raise for non-map-partitionable `getitem` calls with ellipsis

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -893,7 +893,14 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
                 return self._getitem_outer_bool_or_int_lazy_array(where)
 
         elif where[0] is Ellipsis:
-            return self._getitem_trivial_map_partitions(where)
+            if len(where) <= self.ndim:
+                return self._getitem_trivial_map_partitions(where)
+
+            raise DaskAwkwardNotImplemented(
+                "Array slicing doesn't currently support Ellipsis where "
+                "the total number of sliced axes is greater than the "
+                "dimensionality of the array."
+            )
 
         raise DaskAwkwardNotImplemented(
             f"Array.__getitem__ doesn't support multi object: {where}"

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -135,8 +135,25 @@ def test_boolean_array_from_concatenated(daa: dak.Array) -> None:
     assert_eq(d_concat[d_concat.x > 2], c_concat[c_concat.x > 2])
 
 
-def test_firstarg_ellipsis() -> None:
+def test_firstarg_ellipsis_3d() -> None:
     # Making a triply nested array
-    caa = ak.from_regular(np.random.random(size=(5, 5, 5)))
-    daa = dak.from_awkward(caa, npartitions=2)
+    caa = ak.from_regular(np.random.random(size=(9, 5, 5)))
+    daa = dak.from_awkward(caa, npartitions=3)
     assert_eq(daa[..., 1:3], caa[..., 1:3])
+    assert_eq(daa[..., 0:, 2:4], caa[..., 0:, 2:4])
+
+
+def test_firstarg_ellipsis_2d() -> None:
+    caa = ak.from_regular(np.random.random(size=(9, 5)))
+    daa = dak.from_awkward(caa, npartitions=3)
+    assert_eq(daa[..., 1:3], caa[..., 1:3])
+
+
+def test_firstarg_ellipsis_bad() -> None:
+    caa = ak.Array({"x": [1, 2, 3, 4]})
+    daa = dak.from_awkward(caa, npartitions=2)
+    with pytest.raises(
+        DaskAwkwardNotImplemented,
+        match="sliced axes is greater than",
+    ):
+        daa[..., 0]


### PR DESCRIPTION
Follow up to #217; there are some cases that are not map-partitionable; for now raise on those.