### PR TITLE
Modify workaround for touching `what` in dak.with_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "awkward >=2.1.2",
+  "awkward >=2.1.3",
   "dask >=2022.02.1",
 ]
 dynamic = ["version"]

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -890,6 +890,9 @@ class _WithFieldFn:
         self.behavior = behavior
 
     def __call__(self, base: ak.Array, what: ak.Array) -> ak.Array:
+        # TODO: remove backend handling when touch is handled automatically
+        if ak.backend(what) == "typetracer":
+            what.layout._touch_data(recursive=False)
         return ak.with_field(
             base,
             what,

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -890,9 +890,6 @@ class _WithFieldFn:
         self.behavior = behavior
 
     def __call__(self, base: ak.Array, what: ak.Array) -> ak.Array:
-        # TODO: remove backend handling when touch is handled automatically
-        if ak.backend(what) == "typetracer":
-            what.layout._touch_data(recursive=True)
         return ak.with_field(
             base,
             what,


### PR DESCRIPTION
This can be relaxed now but is still a consequence of #223.