### PR TITLE
Substitute in self for _dask_array_ when it is not specified

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -980,6 +980,8 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             themethod = getattr(self._meta, method_name)
             thesig = inspect.signature(themethod)
             if "_dask_array_" in thesig.parameters:
+                if "_dask_array_" not in kwargs:
+                    kwargs["_dask_array_"] = self
                 return themethod(*args, **kwargs)
             return self.map_partitions(
                 _BehaviorMethodFn(method_name, **kwargs),

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -54,7 +54,7 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
 
     assert daa.non_dask_property == caa.non_dask_property
 
-    assert daa.non_dask_method() == daa
+    assert repr(daa.non_dask_method()) == repr(daa)
 
 
 def test_nonexistent_behavior(daa_p1: dak.Array, daa_p2: dak.Array) -> None:

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -22,11 +22,11 @@ class Point:
     @ak.mixin_class_method(np.abs)
     def point_abs(self):
         return np.sqrt(self.x**2 + self.y**2)
-    
+
     @property
     def non_dask_property(self, _dask_array_=None):
         return "this is a non-dask property"
-    
+
     def non_dask_method(self, _dask_array_=None):
         return _dask_array_
 
@@ -51,9 +51,9 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
     assert_eq(daa.x2, caa.x2)
 
     assert daa.behavior == caa.behavior
-    
+
     assert daa.non_dask_property == caa.non_dask_property
-    
+
     assert daa.non_dask_method() == daa
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -22,6 +22,13 @@ class Point:
     @ak.mixin_class_method(np.abs)
     def point_abs(self):
         return np.sqrt(self.x**2 + self.y**2)
+    
+    @property
+    def non_dask_property(self, _dask_array_=None):
+        return "this is a non-dask property"
+    
+    def non_dask_method(self, _dask_array_=None):
+        return _dask_array_
 
 
 def test_distance_behavior(
@@ -44,6 +51,10 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
     assert_eq(daa.x2, caa.x2)
 
     assert daa.behavior == caa.behavior
+    
+    assert daa.non_dask_property == caa.non_dask_property
+    
+    assert daa.non_dask_method() == daa
 
 
 def test_nonexistent_behavior(daa_p1: dak.Array, daa_p2: dak.Array) -> None:


### PR DESCRIPTION
remove odd constructions in user code like:
```python3
events.some_behavior_method(*args, _dask_array_=events)
```