### PR TITLE
feat: Allow `dak.where`, `dak.with_field` and `__setitem__` to take some non-array arguments

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -526,9 +526,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         ):
             raise TypeError("only fields may be assigned in-place (by field name)")
 
-        if not isinstance(what, Array):
+        if not isinstance(what, (Array, Number)):
             raise DaskAwkwardNotImplemented(
-                "Supplying anything other than a dak.Array to __setitem__ is not yet available!"
+                "Supplying anything other than a dak.Array, or Number to __setitem__ is not yet available!"
             )
 
         from dask_awkward.lib.structure import with_field

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import warnings
 from collections.abc import Sequence
+from numbers import Number
 from typing import TYPE_CHECKING, Any
 
 import awkward as ak
@@ -829,6 +830,7 @@ class _WhereFn:
         self.behavior = behavior
 
     def __call__(self, condition: ak.Array, x: ak.Array, y: ak.Array) -> ak.Array:
+        # TODO: remove backend handling when touch/non-array arg is handled automatically
         if ak.backend(condition) == "typetracer":
             lz_condition = condition.layout.form.length_zero_array(
                 behavior=condition.behavior
@@ -904,9 +906,26 @@ class _WithFieldFn:
         self.behavior = behavior
 
     def __call__(self, base: ak.Array, what: ak.Array) -> ak.Array:
-        # TODO: remove backend handling when touch is handled automatically
-        if ak.backend(what) == "typetracer":
-            what.layout._touch_data(recursive=False)
+        # TODO: remove backend handling when touch/non-array arg is handled automatically
+        if ak.backend(base) == "typetracer":
+            what_is_tt = False
+            if isinstance(what, ak.Array) and ak.backend(what) == "typetracer":
+                what_is_tt = True
+                what.layout._touch_data(recursive=False)
+            if not what_is_tt:
+                zl_base = base.layout.form.length_zero_array(behavior=base.behavior)
+                zl_out = ak.with_field(
+                    zl_base,
+                    what,
+                    where=self.where,
+                    highlevel=self.highlevel,
+                    behavior=self.behavior,
+                )
+                return ak.Array(
+                    zl_out.layout.to_typetracer(forget_length=True),
+                    behavior=zl_out.behavior,
+                )
+
         return ak.with_field(
             base,
             what,
@@ -923,6 +942,11 @@ def with_field(base, what, where=None, highlevel=True, behavior=None):
 
     if not isinstance(base, Array):
         raise ValueError("Base argument in with_field must be a dask_awkward.Array")
+
+    if not isinstance(what, (Array, Number)):
+        raise ValueError(
+            "with_field cannot accept string, bytes, list, or dict values yet"
+        )
 
     maybe_dask_args = [base, what]
     dask_args = tuple(arg for arg in maybe_dask_args if is_dask_collection(arg))

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -249,6 +249,29 @@ def test_where(caa, daa, mergebool):
         ),
     )
 
+    assert_eq(
+        dak.where(
+            daa.points.x > daa.points.y, daa.points.x, 9999.0, mergebool=mergebool
+        ),
+        ak.where(
+            caa.points.x > caa.points.y, caa.points.x, 9999.0, mergebool=mergebool
+        ),
+    )
+
+    assert_eq(
+        dak.where(
+            daa.points.x > daa.points.y, 9999.0, daa.points.y, mergebool=mergebool
+        ),
+        ak.where(
+            caa.points.x > caa.points.y, 9999.0, caa.points.y, mergebool=mergebool
+        ),
+    )
+
+    assert_eq(
+        dak.where(daa.points.x > daa.points.y, 8888.0, 9999.0, mergebool=mergebool),
+        ak.where(caa.points.x > caa.points.y, 8888.0, 9999.0, mergebool=mergebool),
+    )
+
 
 def test_isclose(daa, caa):
     assert_eq(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -174,6 +174,28 @@ def test_with_field(caa: ak.Array, daa: dak.Array) -> None:
         dak.with_field(daa["points"], daa["points"]["x"], where="xx"),
     )
 
+    assert_eq(
+        ak.with_field(caa["points"], 1, where="xx"),
+        dak.with_field(daa["points"], 1, where="xx"),
+    )
+
+    assert_eq(
+        ak.with_field(caa["points"], 1.0, where="xx"),
+        dak.with_field(daa["points"], 1.0, where="xx"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Base argument in with_field must be a dask_awkward.Array",
+    ):
+        _ = dak.with_field([{"foo": 1.0}, {"foo": 2.0}], daa.points.x, where="x")
+
+    with pytest.raises(
+        ValueError,
+        match="with_field cannot accept string, bytes, list, or dict values yet",
+    ):
+        _ = dak.with_field(daa["points"], "hi there", where="q")
+
 
 def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
     daa["xx"] = daa["points"]["x"]
@@ -182,6 +204,12 @@ def test_setitem(caa: ak.Array, daa: dak.Array) -> None:
     daa["points", "z"] = np.sqrt(daa.points.x**2 + daa.points.y**2)
     caa["points", "z"] = np.sqrt(caa.points.x**2 + caa.points.y**2)
     assert_eq(caa, daa)
+
+    with pytest.raises(
+        DaskAwkwardNotImplemented,
+        match="Supplying anything other than a dak.Array, or Number to __setitem__ is not yet available!\n\nIf you would like this unsupported call to be supported by\ndask-awkward please open an issue at:\nhttps://github.com/dask-contrib/dask-awkward.",
+    ):
+        daa["points", "q"] = "hi there"
 
 
 def test_with_parameter() -> None:


### PR DESCRIPTION
Partially fixes #226 for `where` and `with_field`

Allows users to pass in non-dak arguments for certain arugments of where and with_field.

@yimuchen