### PR TITLE
fix: make ak.singletons workaround operate correctly in all cases

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -700,29 +700,36 @@ def run_lengths(array, highlevel=True, behavior=None):
     )
 
 
+class _SingletonsFn:
+    def __init__(self, axis, **kwargs):
+        self.axis = axis
+        self.kwargs = kwargs
+
+    def __call__(self, array):
+        # TODO: remove this length-zero calculation once https://github.com/scikit-hep/awkward/issues/2123 is addressed
+        if ak.backend(array) == "typetracer":
+            array.layout._touch_data(recursive=False)
+            zl_out = ak.singletons(
+                array.layout.form.length_zero_array(behavior=array.behavior),
+                axis=self.axis,
+                **self.kwargs,
+            )
+            return ak.Array(
+                zl_out.layout.to_typetracer(forget_length=True),
+                behavior=zl_out.behavior,
+            )
+        return ak.singletons(array, axis=self.axis, **self.kwargs)
+
+
 @borrow_docstring(ak.singletons)
 def singletons(array, axis=0, highlevel=True, behavior=None):
     if not highlevel:
         raise ValueError("Only highlevel=True is supported")
 
-    # TODO: remove this length-zero calculation once https://github.com/scikit-hep/awkward/issues/2123 is addressed
-    meta = typetracer_from_form(
-        ak.singletons(
-            array._meta.layout.form.length_zero_array(behavior=array.behavior),
-            axis=axis,
-            highlevel=highlevel,
-            behavior=behavior,
-        ).layout.form
-    )
-
     return map_partitions(
-        ak.singletons,
+        _SingletonsFn(axis, highlevel=highlevel, behavior=behavior),
         array,
-        axis=axis,
-        highlevel=highlevel,
-        behavior=behavior,
         label="singletons",
-        meta=meta,
     )
 
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -250,12 +250,31 @@ def test_isclose(daa, caa):
     )
 
 
-def test_singletons(L4):
-    caa = ak.Array(L4)
-    daa = dak.from_awkward(caa, 1)
+def test_singletons(daa, L4):
+    import warnings
+
+    warnings.simplefilter("error")
+    caa_L4 = ak.Array(L4)
+    daa_L4 = dak.from_awkward(caa_L4, 1)
     assert_eq(
-        dak.singletons(daa),
-        ak.singletons(caa),
+        dak.singletons(daa_L4),
+        ak.singletons(caa_L4),
+    )
+
+    dak.to_parquet(daa, "test-singletons/")
+
+    fpq_daa = dak.from_parquet("test-singletons/")
+    fpq_caa = ak.from_parquet("test-singletons/")
+
+    temp_zip = dak.zip({"x": fpq_daa.points.x, "y": fpq_daa.points.y})
+
+    argmin_check = dak.singletons(dak.argmin(temp_zip.x, axis=1))
+
+    assert_eq(
+        argmin_check,
+        ak.singletons(
+            ak.argmin(ak.zip({"x": fpq_caa.points.x, "y": fpq_caa.points.y}).x, axis=1)
+        ),
     )
 
 


### PR DESCRIPTION
Present implementation of singletons was failing column optimization when passed RecordArrays that were then accessed later.