### PR TITLE
fix: drop workarounds for typetracer, use `highlevel=False`

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1737,7 +1737,7 @@ def to_meta(objects: Sequence[Any]) -> tuple[Any, ...]:
 
 def length_zero_array_or_identity(obj: Any) -> Any:
     if is_awkward_collection(obj):
-        return obj._meta.layout.form.length_zero_array(behavior=obj.behavior)
+        return ak.Array(obj._meta.layout.form.length_zero_array(highlevel=False), behavior=obj.behavior)
     return obj
 
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1737,7 +1737,10 @@ def to_meta(objects: Sequence[Any]) -> tuple[Any, ...]:
 
 def length_zero_array_or_identity(obj: Any) -> Any:
     if is_awkward_collection(obj):
-        return ak.Array(obj._meta.layout.form.length_zero_array(highlevel=False), behavior=obj.behavior)
+        return ak.Array(
+            obj._meta.layout.form.length_zero_array(highlevel=False),
+            behavior=obj.behavior,
+        )
     return obj
 
 

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -17,7 +17,6 @@ from dask_awkward.lib.core import (
     map_partitions,
     new_known_scalar,
     total_reduction_to_scalar,
-    typetracer_from_form,
 )
 from dask_awkward.utils import (
     DaskAwkwardNotImplemented,
@@ -919,7 +918,7 @@ def with_name(
         _WithNameFn(name=name, behavior=behavior),
         array,
         label="with-name",
-        output_divisions=1
+        output_divisions=1,
     )
 
 

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -683,18 +683,6 @@ class _SingletonsFn:
         self.kwargs = kwargs
 
     def __call__(self, array):
-        # TODO: remove this length-zero calculation once https://github.com/scikit-hep/awkward/issues/2123 is addressed
-        if ak.backend(array) == "typetracer":
-            array.layout._touch_data(recursive=False)
-            zl_out = ak.singletons(
-                array.layout.form.length_zero_array(behavior=array.behavior),
-                axis=self.axis,
-                **self.kwargs,
-            )
-            return ak.Array(
-                zl_out.layout.to_typetracer(forget_length=True),
-                behavior=zl_out.behavior,
-            )
         return ak.singletons(array, axis=self.axis, **self.kwargs)
 
 
@@ -769,17 +757,6 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
         otherwise this unflatten operation will fail when computed!"""
     )
 
-    #  TODO: remove after fixing issue in awkward
-    meta = typetracer_from_form(
-        ak.unflatten(
-            array._meta.layout.form.length_zero_array(behavior=array.behavior),
-            counts._meta.layout.form.length_zero_array(behavior=counts.behavior),
-            axis=axis,
-            highlevel=highlevel,
-            behavior=behavior,
-        ).layout.form
-    )
-
     return map_partitions(
         ak.unflatten,
         array,
@@ -787,7 +764,6 @@ def unflatten(array, counts, axis=0, highlevel=True, behavior=None):
         axis=axis,
         highlevel=highlevel,
         behavior=behavior,
-        meta=meta,
         label="unflatten",
     )
 
@@ -939,25 +915,11 @@ def with_name(
     if not highlevel:
         raise ValueError("Only highlevel=True is supported")
 
-    #  TODO: remove once fixed in awkward
-    meta = ak.Array(
-        typetracer_from_form(
-            ak.with_name(
-                array._meta.layout.form.length_zero_array(),
-                name,
-                highlevel=highlevel,
-                behavior=behavior,
-            ).layout.form
-        ),
-        behavior=behavior if behavior is not None else array._meta.behavior,
-    )
-
     return map_partitions(
         _WithNameFn(name=name, behavior=behavior),
         array,
         label="with-name",
-        output_divisions=1,
-        meta=meta,
+        output_divisions=1
     )
 
 


### PR DESCRIPTION
This PR removes the last `length_zero_array()` usages in the dask-awkward operations, and also accounts for an upcoming deprecation of `highlevel=True` in `length_zero_array` (scikit-hep/awkward#2435)