### PR TITLE
fix: import `typetracer_with_report` from L2 module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "awkward >=2.1.3",
+  "awkward >=2.2.1",
   "dask >=2023.04.0",
 ]
 dynamic = ["version"]

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -10,7 +10,7 @@ from dask.blockwise import Blockwise, BlockwiseDepDict, blockwise_token
 from dask_awkward.utils import LazyInputsDict
 
 if TYPE_CHECKING:
-    from awkward._nplikes.typetracer import TypeTracerReport
+    from awkward.typetracer import TypeTracerReport
 
 
 class AwkwardBlockwiseLayer(Blockwise):
@@ -145,7 +145,7 @@ class AwkwardInputLayer(AwkwardBlockwiseLayer):
 
         set_form_keys(form, key=self.name)
 
-        new_meta_labelled, report = ak._nplikes.typetracer.typetracer_with_report(form)
+        new_meta_labelled, report = ak.typetracer.typetracer_with_report(form)
         new_meta_array = ak.Array(new_meta_labelled, behavior=self._behavior)
         new_input_layer = AwkwardInputLayer(
             name=self.name,


### PR DESCRIPTION
> **Warning**
> This will require a pin on a future release of awkward (2.2.1). 

We're gradually exporting any clearly-needed features from Awkward into a public (L2) module, in this instance `ak.typetracer`. This PR makes use of these symbols.