### PR TITLE
feat: add comprehensive `axis=0` and `axis=None` reduction

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1478,7 +1478,6 @@ def _from_iter(obj):
     representation of the input iterable-of-typetracers.
 
     """
-    breakpoint()
     try:
         return ak.from_iter(obj)
     except (ValueError, TypeError):

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1539,9 +1539,18 @@ def _next_chunk_partition_offset(chunk: ak.Array, axis: int | None):
 def _chunk_reducer_positional(
     chunk: ak.Array, axis: int | None, *, reducer: Callable
 ) -> PartialPositionalReductionType:
+    # TODO: this is private Awkward code. We should figure out how to export it
+    # if needed
+    layout, = ak._do.remove_structure(
+        ak.to_layout(chunk),
+        flatten_records=False,
+        drop_nones=False,
+        keepdims=True,
+        allow_records=False,
+    )
+    chunk = ak.Array(layout, behavior=chunk.behavior)
+
     index = reducer(chunk, axis=axis, keepdims=True, mask_identity=True)
-    # TODO: chunk needs to be flattened in the same way that reducer(chunk, axis=None, keepdims=True)
-    # does in order to preserve the index-ability
     # Adjust the index to be absolute w.r.t the original array
     return index, chunk[index], _next_chunk_partition_offset(chunk, axis)
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -6,9 +6,9 @@ import logging
 import operator
 import sys
 import warnings
-from itertools import accumulate, islice
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from functools import cached_property, partial
+from itertools import accumulate, islice
 from numbers import Number
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
@@ -1498,7 +1498,11 @@ PartialReductionType = ak.Array
 
 
 def _chunk_reducer_trivial(
-    chunk: ak.Array | PartialReductionType, axis: int | None, *, reducer: Callable, mask_identity: bool
+    chunk: ak.Array | PartialReductionType,
+    axis: int | None,
+    *,
+    reducer: Callable,
+    mask_identity: bool,
 ) -> PartialReductionType:
     return reducer(chunk, keepdims=True, axis=axis, mask_identity=mask_identity)
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from functools import cached_property, partial
-from itertools import accumulate, islice
+from itertools import accumulate
 from numbers import Number
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1586,12 +1586,12 @@ def _concat_reducer_positional(
 
 # Interior reductions don't need starts
 def _tree_node_reducer_positional(
-    partial: PartialPositionalReductionType, *, reducer: Callable
+    partial: PartialPositionalReductionType, is_axis_none: bool, *, reducer: Callable
 ) -> PartialPositionalReductionType:
     # `partial` comes from `concat`
     partial_index, partial_value, partial_length = partial
     final_index_index = reducer(
-        partial_value, axis=-1, keepdims=True, mask_identity=True
+        partial_value, axis=-1 if is_axis_none else 0, keepdims=True, mask_identity=True
     )
     # Indices are already absolute!
     return (
@@ -1659,7 +1659,7 @@ def non_trivial_reduction(
         finalize_fn = _finalise_reducer_positional
 
         chunked_kwargs = {"reducer": reducer, "is_axis_none": axis is None}
-        tree_node_kwargs = {"reducer": reducer}
+        tree_node_kwargs = {"reducer": reducer, "is_axis_none": axis is None}
 
     else:
         chunked_fn = _chunk_reducer_trivial

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1518,7 +1518,7 @@ def _finalise_reducer_trivial(
     return reducer(partial, axis=0, keepdims=keepdims, mask_identity=mask_identity)
 
 
-PartialPositionalReductionType = tuple[ak.Array, ak.Array]
+PartialPositionalReductionType = "tuple[ak.Array, ak.Array]"
 
 
 # Exterior reductions need starts!

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1578,7 +1578,6 @@ def axis_0_reduction(
     *,
     label: str,
     array: Array,
-    meta: Any,
     is_positional: bool,
     keepdims: bool,
     mask_identity: bool,
@@ -1663,6 +1662,12 @@ def axis_0_reduction(
 
     graph = HighLevelGraph.from_collections(
         name_finalize, dftr, dependencies=(chunked_result,)
+    )
+    meta = reducer(
+        array._meta,
+        axis=0,
+        keepdims=keepdims,
+        mask_identity=mask_identity,
     )
     if isinstance(meta, ak.highlevel.Array):
         return new_array_object(graph, name_finalize, meta=meta, npartitions=1)

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1507,7 +1507,7 @@ def _chunk_reducer_trivial(
     return reducer(
         chunk,
         keepdims=True,
-        axis=None if is_axis_none else 0,
+        axis=-1 if is_axis_none else 0,
         mask_identity=mask_identity,
     )
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1538,14 +1538,14 @@ def _finalise_reducer_trivial(
 PartialPositionalReductionType = "tuple[ak.Array, ak.Array, int]"
 
 
-def _next_chunk_partition_offset(chunk: ak.Array, is_axis_none: bool):
+def _next_chunk_partition_offset(chunk: ak.Array, is_axis_none: bool) -> int:
     if is_axis_none:
         return len(ak.ravel(chunk))
     else:
         return len(chunk)
 
 
-def _prepare_axis_none(chunk: ak.Array):
+def _prepare_axis_none_chunk(chunk: ak.Array) -> ak.Array:
     # TODO: this is private Awkward code. We should figure out how to export it
     # if needed
     (layout,) = ak._do.remove_structure(
@@ -1711,7 +1711,7 @@ def non_trivial_reduction(
     # For axis=None, let's remove the structure to make the internal operations
     # axis=-1
     if axis is None:
-        array = map_partitions(_prepare_axis_none, array, meta=empty_typetracer())
+        array = map_partitions(_prepare_axis_none_chunk, array, meta=empty_typetracer())
 
     chunked_result = map_partitions(
         chunked_fn,

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1600,6 +1600,7 @@ def axis_0_reduction(
 
     from dask.layers import DataFrameTreeReduction
 
+    chunked_kwargs = {"reducer": reducer, "mask_identity": mask_identity}
     tree_node_kwargs = chunked_kwargs
     concat_kwargs = {}
     finalize_kwargs = {

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1712,11 +1712,15 @@ def non_trivial_reduction(
     # For axis=None, let's remove the structure to make the internal operations
     # axis=-1
     if axis is None:
-        array = map_partitions(_prepare_axis_none_chunk, array, meta=empty_typetracer())
+        prepared_array = map_partitions(
+            _prepare_axis_none_chunk, array, meta=empty_typetracer()
+        )
+    else:
+        prepared_array = array
 
     chunked_result = map_partitions(
         chunked_fn,
-        array,
+        prepared_array,
         meta=empty_typetracer(),
     )
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1708,7 +1708,7 @@ def non_trivial_reduction(
         "is_axis_none": axis is None,
     }
 
-    from dask.layers import DataFrameTreeReduction
+    from dask_awkward.layers import AwkwardTreeReductionLayer
 
     token = token or tokenize(
         array,
@@ -1739,7 +1739,7 @@ def non_trivial_reduction(
     name_chunked = f"{label}-prepare-{token}"
     chunked = partitionwise_layer(chunked_fn, name_chunked, prepared_array)
 
-    dftr = DataFrameTreeReduction(
+    trl = AwkwardTreeReductionLayer(
         name=name_finalize,
         name_input=name_chunked,
         npartitions_input=prepared_array.npartitions,
@@ -1752,7 +1752,7 @@ def non_trivial_reduction(
 
     # Build graph
     prepared_array_graph = prepared_array.__dask_graph__()
-    layers = {name_finalize: dftr, name_chunked: chunked, **prepared_array_graph.layers}
+    layers = {name_finalize: trl, name_chunked: chunked, **prepared_array_graph.layers}
     dependencies = {
         name_finalize: {name_chunked},
         name_chunked: {prepared_array.name},

--- a/src/dask_awkward/lib/reducers.py
+++ b/src/dask_awkward/lib/reducers.py
@@ -46,7 +46,32 @@ def all(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis and axis != 0:
+    if axis is None:
+        return total_reduction_to_scalar(
+            label="all",
+            array=array,
+            chunked_fn=ak.all,
+            chunked_kwargs={
+                "axis": None,
+                "mask_identity": mask_identity,
+            },
+            meta=ak.sum(
+                array._meta,
+                axis=None,
+                keepdims=keepdims,
+                mask_identity=mask_identity,
+            ),
+        )
+    elif axis == 0 or axis == -1 * array.ndim:
+        return axis_0_reduction(
+            label="all",
+            array=array,
+            reducer=ak.all,
+            is_positional=False,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
+    else:
         return map_partitions(
             ak.all,
             array,
@@ -55,7 +80,6 @@ def all(
             keepdims=keepdims,
             mask_identity=mask_identity,
         )
-    raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
 
 
 @borrow_docstring(ak.any)
@@ -65,7 +89,32 @@ def any(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis and axis != 0:
+    if axis is None:
+        return total_reduction_to_scalar(
+            label="any",
+            array=array,
+            chunked_fn=ak.any,
+            chunked_kwargs={
+                "axis": None,
+                "mask_identity": mask_identity,
+            },
+            meta=ak.sum(
+                array._meta,
+                axis=None,
+                keepdims=keepdims,
+                mask_identity=mask_identity,
+            ),
+        )
+    elif axis == 0 or axis == -1 * array.ndim:
+        return axis_0_reduction(
+            label="any",
+            array=array,
+            reducer=ak.any,
+            is_positional=False,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
+    else:
         return map_partitions(
             ak.any,
             array,
@@ -74,7 +123,6 @@ def any(
             keepdims=keepdims,
             mask_identity=mask_identity,
         )
-    raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
 
 
 @borrow_docstring(ak.argmax)
@@ -154,10 +202,6 @@ def count(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="count",
@@ -198,10 +242,6 @@ def count_nonzero(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="count_nonzero",
@@ -335,10 +375,6 @@ def min(
     initial: float | None = None,
     mask_identity: bool = True,
 ) -> Any:
-    if axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="min",
@@ -389,10 +425,6 @@ def moment(
 
 @borrow_docstring(ak.prod)
 def prod(array, axis=None, keepdims=False, mask_identity=False):
-    if axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="prod",
@@ -483,10 +515,6 @@ def sum(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="sum",

--- a/src/dask_awkward/lib/reducers.py
+++ b/src/dask_awkward/lib/reducers.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import awkward as ak
 
-from dask_awkward.lib.core import (
-    non_trivial_reduction,
-    map_partitions
-)
+from dask_awkward.lib.core import map_partitions, non_trivial_reduction
 from dask_awkward.utils import DaskAwkwardNotImplemented, borrow_docstring
 
 if TYPE_CHECKING:

--- a/src/dask_awkward/lib/reducers.py
+++ b/src/dask_awkward/lib/reducers.py
@@ -154,20 +154,11 @@ def count(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis == 0 or axis == -1 * array.ndim:
+    if axis == -1 * array.ndim:
         raise DaskAwkwardNotImplemented(
             f"axis={axis} is not supported for this array yet."
         )
-    if axis and axis != 0:
-        return map_partitions(
-            ak.count,
-            array,
-            output_divisions=1,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        )
-    elif axis is None:
+    if axis is None:
         return total_reduction_to_scalar(
             label="count",
             array=array,
@@ -179,8 +170,25 @@ def count(
             agg_fn=ak.sum,
             agg_kwargs={"axis": None},
         )
+    elif axis == 0 or axis == -1 * array.ndim:
+        return axis_0_reduction(
+            label="count",
+            array=array,
+            reducer=ak.count,
+            combiner=ak.sum,
+            is_positional=False,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
     else:
-        raise ValueError("axis must be None or an integer.")
+        return map_partitions(
+            ak.count,
+            array,
+            output_divisions=1,
+            axis=axis,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
 
 
 @borrow_docstring(ak.count_nonzero)
@@ -190,20 +198,11 @@ def count_nonzero(
     keepdims: bool = False,
     mask_identity: bool = False,
 ) -> Any:
-    if axis == 0 or axis == -1 * array.ndim:
+    if axis == -1 * array.ndim:
         raise DaskAwkwardNotImplemented(
             f"axis={axis} is not supported for this array yet."
         )
-    if axis and axis != 0:
-        return map_partitions(
-            ak.count_nonzero,
-            array,
-            output_divisions=1,
-            axis=1,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        )
-    elif axis is None:
+    if axis is None:
         return total_reduction_to_scalar(
             label="count_nonzero",
             array=array,
@@ -215,8 +214,25 @@ def count_nonzero(
             agg_fn=ak.sum,
             agg_kwargs={"axis": None},
         )
+    elif axis == 0 or axis == -1 * array.ndim:
+        return axis_0_reduction(
+            label="count_nonzero",
+            array=array,
+            reducer=ak.count_nonzero,
+            combiner=ak.sum,
+            is_positional=False,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
     else:
-        raise ValueError("axis must be None or an integer.")
+        return map_partitions(
+            ak.count_nonzero,
+            array,
+            output_divisions=1,
+            axis=axis,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
 
 
 @borrow_docstring(ak.covar)
@@ -251,20 +267,6 @@ def max(
     initial: float | None = None,
     mask_identity: bool = True,
 ) -> Any:
-    if axis == 0 or axis == -1 * array.ndim:
-        raise DaskAwkwardNotImplemented(
-            f"axis={axis} is not supported for this array yet."
-        )
-    if axis and axis != 0:
-        return map_partitions(
-            ak.max,
-            array,
-            output_divisions=1,
-            axis=axis,
-            keepdims=keepdims,
-            initial=initial,
-            mask_identity=mask_identity,
-        )
     if axis is None:
         return total_reduction_to_scalar(
             label="max",
@@ -274,10 +276,31 @@ def max(
                 "axis": None,
                 "mask_identity": mask_identity,
             },
-            meta=ak.max(array._meta, axis=None),
+            meta=ak.max(
+                array._meta,
+                axis=None,
+                keepdims=keepdims,
+                mask_identity=mask_identity,
+            ),
+        )
+    elif axis == 0 or axis == -1 * array.ndim:
+        return axis_0_reduction(
+            label="max",
+            array=array,
+            reducer=ak.max,
+            is_positional=False,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
         )
     else:
-        raise DaskAwkwardNotImplemented(f"axis={axis} is a TODO")
+        return map_partitions(
+            ak.max,
+            array,
+            output_divisions=1,
+            axis=axis,
+            keepdims=keepdims,
+            mask_identity=mask_identity,
+        )
 
 
 @borrow_docstring(ak.mean)
@@ -332,7 +355,7 @@ def min(
                 mask_identity=mask_identity,
             ),
         )
-    elif axis == 0:
+    elif axis == 0 or axis == -1 * array.ndim:
         return axis_0_reduction(
             label="min",
             array=array,
@@ -386,7 +409,7 @@ def prod(array, axis=None, keepdims=False, mask_identity=False):
                 mask_identity=mask_identity,
             ),
         )
-    elif axis == 0:
+    elif axis == 0 or axis == -1 * array.ndim:
         return axis_0_reduction(
             label="prod",
             array=array,
@@ -480,7 +503,7 @@ def sum(
                 mask_identity=mask_identity,
             ),
         )
-    elif axis == 0:
+    elif axis == 0 or axis == -1 * array.ndim:
         return axis_0_reduction(
             label="sum",
             array=array,

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -28,7 +28,7 @@ def test_all(
     assert_eq(ar, dr)
 
 
-@pytest.mark.parametrize("axis", [1, -1])
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 @pytest.mark.parametrize("testval", [-1, 3, 100])
@@ -49,8 +49,16 @@ def test_any(
     assert_eq(ar, dr)
 
 
-@pytest.mark.parametrize("axis", [1])
-def test_argmax(daa: dak.Array, caa: ak.Array, axis: int) -> None:
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_argmax(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
     xd = daa.points.x
     xc = caa.points.x
     dr = dak.argmax(xd, axis=axis)
@@ -58,8 +66,16 @@ def test_argmax(daa: dak.Array, caa: ak.Array, axis: int) -> None:
     assert_eq(dr, ar)
 
 
-@pytest.mark.parametrize("axis", [1])
-def test_argmin(daa: dak.Array, caa: ak.Array, axis: int) -> None:
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_argmin(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
     xd = daa.points.x
     xc = caa.points.x
     dr = dak.argmin(xd, axis=axis)
@@ -67,15 +83,31 @@ def test_argmin(daa: dak.Array, caa: ak.Array, axis: int) -> None:
     assert_eq(dr, ar)
 
 
-@pytest.mark.parametrize("axis", [None, 1, -1])
-def test_count(daa: dak.Array, caa: ak.Array, axis: int | None) -> None:
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_count(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
     ar = ak.count(caa["points"]["x"], axis=axis)
     dr = dak.count(daa["points"]["x"], axis=axis)
     assert_eq(ar, dr)
 
 
-@pytest.mark.parametrize("axis", [None, 1, -1])
-def test_count_nonzero(daa: dak.Array, caa: ak.Array, axis: int | None) -> None:
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_count_nonzero(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
     ar = ak.count_nonzero(caa["points"]["x"], axis=axis)
     dr = dak.count_nonzero(daa["points"]["x"], axis=axis)
     assert_eq(ar, dr)
@@ -83,7 +115,7 @@ def test_count_nonzero(daa: dak.Array, caa: ak.Array, axis: int | None) -> None:
 
 @pytest.mark.parametrize("axis", [None, 1, -1])
 @pytest.mark.parametrize("attr", ["x", "y"])
-def test_max(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_max(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.max(caa.points[attr], axis=axis)
     dr = dak.max(daa.points[attr], axis=axis)
     assert_eq(ar, dr)
@@ -91,7 +123,7 @@ def test_max(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None
 
 @pytest.mark.parametrize("axis", [1, -1])
 @pytest.mark.parametrize("attr", ["y", "x"])
-def test_mean(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_mean(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.mean(caa.points[attr], axis=axis)
     dr = dak.mean(daa.points[attr], axis=axis)
     assert_eq(ar, dr, isclose_equal_nan=True)
@@ -99,7 +131,7 @@ def test_mean(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> Non
 
 @pytest.mark.parametrize("axis", [None, 1, -1])
 @pytest.mark.parametrize("attr", ["x", "y"])
-def test_min(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_min(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.min(caa.points[attr], axis=axis)
     dr = dak.min(daa["points"][attr], axis=axis)
     assert_eq(ar, dr)
@@ -107,7 +139,7 @@ def test_min(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None
 
 @pytest.mark.parametrize("axis", [None, 1, -1])
 @pytest.mark.parametrize("attr", ["x", "y"])
-def test_sum(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_sum(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.sum(caa.points[attr], axis=axis)
     dr = dak.sum(daa.points[attr], axis=axis)
     assert_eq(ar, dr)
@@ -115,7 +147,7 @@ def test_sum(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None
 
 @pytest.mark.parametrize("axis", [1, -1])
 @pytest.mark.parametrize("attr", ["y", "x"])
-def test_var(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_var(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.var(caa.points[attr], axis=axis)
     dr = dak.var(daa.points[attr], axis=axis)
     assert_eq(ar, dr, isclose_equal_nan=True)
@@ -123,7 +155,7 @@ def test_var(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None
 
 @pytest.mark.parametrize("axis", [1, -1])
 @pytest.mark.parametrize("attr", ["y", "x"])
-def test_std(daa: dak.Array, caa: ak.Array, axis: int | None, attr: str) -> None:
+def test_std(daa: dak.Array, caa: ak.Array, axis: int, attr: str) -> None:
     ar = ak.std(caa.points[attr], axis=axis)
     dr = dak.std(daa.points[attr], axis=axis)
     assert_eq(ar, dr, isclose_equal_nan=True)

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -7,7 +7,7 @@ import dask_awkward as dak
 from dask_awkward.lib.testutils import assert_eq
 
 
-@pytest.mark.parametrize("axis", [1, -1])
+@pytest.mark.parametrize("axis", [1, -1, 0, None])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 @pytest.mark.parametrize("testval", [-1, 3, 100])

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -49,7 +49,7 @@ def test_any(
     assert_eq(ar, dr)
 
 
-@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.parametrize("axis", [1, -1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 def test_argmax(
@@ -61,12 +61,32 @@ def test_argmax(
 ) -> None:
     xd = daa.points.x
     xc = caa.points.x
-    dr = dak.argmax(xd, axis=axis)
-    ar = ak.argmax(xc, axis=axis)
+    dr = dak.argmax(xd, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    ar = ak.argmax(xc, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
     assert_eq(dr, ar)
 
 
-@pytest.mark.parametrize("axis", [1, -1, 0, None])
+@pytest.mark.xfail(
+    reason="positional reducers are not supported for axis=0 and axis=None"
+)
+@pytest.mark.parametrize("axis", [0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_argmax_axis_0_none(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
+    xd = daa.points.x
+    xc = caa.points.x
+    dr = dak.argmax(xd, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    ar = ak.argmax(xc, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    assert_eq(dr, ar)
+
+
+@pytest.mark.parametrize("axis", [1, -1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("mask_identity", [True, False])
 def test_argmin(
@@ -78,8 +98,28 @@ def test_argmin(
 ) -> None:
     xd = daa.points.x
     xc = caa.points.x
-    dr = dak.argmin(xd, axis=axis)
-    ar = ak.argmin(xc, axis=axis)
+    dr = dak.argmin(xd, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    ar = ak.argmin(xc, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    assert_eq(dr, ar)
+
+
+@pytest.mark.xfail(
+    reason="positional reducers are not supported for axis=0 and axis=None"
+)
+@pytest.mark.parametrize("axis", [0, None])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("mask_identity", [True, False])
+def test_argmin_axis_0_none(
+    daa: dak.Array,
+    caa: ak.Array,
+    axis: int,
+    keepdims: bool,
+    mask_identity: bool,
+) -> None:
+    xd = daa.points.x
+    xc = caa.points.x
+    dr = dak.argmin(xd, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
+    ar = ak.argmin(xc, axis=axis, keepdims=keepdims, mask_identity=mask_identity)
     assert_eq(dr, ar)
 
 
@@ -93,8 +133,12 @@ def test_count(
     keepdims: bool,
     mask_identity: bool,
 ) -> None:
-    ar = ak.count(caa["points"]["x"], axis=axis)
-    dr = dak.count(daa["points"]["x"], axis=axis)
+    ar = ak.count(
+        caa["points"]["x"], axis=axis, keepdims=keepdims, mask_identity=mask_identity
+    )
+    dr = dak.count(
+        daa["points"]["x"], axis=axis, keepdims=keepdims, mask_identity=mask_identity
+    )
     assert_eq(ar, dr)
 
 
@@ -108,8 +152,12 @@ def test_count_nonzero(
     keepdims: bool,
     mask_identity: bool,
 ) -> None:
-    ar = ak.count_nonzero(caa["points"]["x"], axis=axis)
-    dr = dak.count_nonzero(daa["points"]["x"], axis=axis)
+    ar = ak.count_nonzero(
+        caa["points"]["x"], axis=axis, keepdims=keepdims, mask_identity=mask_identity
+    )
+    dr = dak.count_nonzero(
+        daa["points"]["x"], axis=axis, keepdims=keepdims, mask_identity=mask_identity
+    )
     assert_eq(ar, dr)
 
 


### PR DESCRIPTION
- ~[x] Support positional reducers~
- [x] Support trivial value reducers
- [x] Support reducers with different combining operations e.g. `ak.count`