### PR TITLE
fix: update to scikit-hep/awkward#2454.

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -681,8 +681,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     def type(self) -> ArrayType:
         """awkward Array type associated with the eventual computed result."""
         t = ak.types.ArrayType(
-            self._meta._layout.form.type_from_behavior(self._meta._behavior),
+            self._meta._layout.form.type,
             0,
+            behavior=self._meta._behavior,
         )
         t._length = "??"
         return t


### PR DESCRIPTION
Update needs this fix for its tests to pass (even [on main](https://github.com/scikit-hep/uproot5/actions/runs/5156709074)).

We'll need a dask-awkward release before we can do another release of Uproot.