### PR TITLE
fix: (in `AwkwardMaterializedLayer.mock`) tasks should be tuples

### DIFF
--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -206,12 +206,10 @@ class AwkwardMaterializedLayer(MaterializedLayer):
         if (name, 0) in mapping:
             task = mapping[(name, 0)]
             task = tuple(
-                [
-                    (self.prev_name, 0)
-                    if isinstance(v, tuple) and len(v) == 2 and v[0] == self.prev_name
-                    else v
-                    for v in task
-                ]
+                (self.prev_name, 0)
+                if isinstance(v, tuple) and len(v) == 2 and v[0] == self.prev_name
+                else v
+                for v in task
             )
             return MaterializedLayer({(name, 0): task})
 

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -205,12 +205,14 @@ class AwkwardMaterializedLayer(MaterializedLayer):
 
         if (name, 0) in mapping:
             task = mapping[(name, 0)]
-            task = [
-                (self.prev_name, 0)
-                if isinstance(v, tuple) and len(v) == 2 and v[0] == self.prev_name
-                else v
-                for v in task
-            ]
+            task = tuple(
+                [
+                    (self.prev_name, 0)
+                    if isinstance(v, tuple) and len(v) == 2 and v[0] == self.prev_name
+                    else v
+                    for v in task
+                ]
+            )
             return MaterializedLayer({(name, 0): task})
 
         # failed to cull during column opt


### PR DESCRIPTION
Dask needs a task to be a `tuple`, if it's a `list` then dask just assumes the `list` is a literal to be returned (basically an already computed thing) instead of a lispy s-expression to be executed
