### PR TITLE
fix: in `unproject_layout` protect against `None` form; add docstring

### DIFF
--- a/src/dask_awkward/lib/unproject_layout.py
+++ b/src/dask_awkward/lib/unproject_layout.py
@@ -374,5 +374,33 @@ def _unproject_layout(form, layout, length, backend):
         raise AssertionError(f"unexpected combination: {type(form)} and {type(layout)}")
 
 
-def unproject_layout(form: Form, layout: Content) -> Content:
+def unproject_layout(form: Form | None, layout: Content) -> Content:
+    """Rehydrate a layout to include all parts of an original form.
+
+    When we perform the necessary columns optimization we drop fields
+    that are not necessary for a computed result. Sometimes we have
+    task graphs that expect to see fields in name only (but no their
+    data). To protect against FieldNotFound exception we "unproject"
+    or "rehydrate" the layout with the original form. This reapplys
+    all original fields, but the ones that were orignally projected
+    away are data-less.
+
+    Parameters
+    ----------
+    form : awkward.forms.form.Form, optional
+        The complete Form to apply to a projected layout. If ``None``,
+        the layout will be returned without unprojection (this case
+        assumes column projection did not occur).
+    layout : awkward.contents.content.Content
+        The projected layout.
+
+    Returns
+    -------
+    awkward.contents.content.Content
+        Unprojected layout (all fields from the original form that did
+        not appear in the projected layout will be PlaceholderArrays).
+
+    """
+    if form is None:
+        return layout
     return _unproject_layout(form, layout, layout.length, layout.backend)


### PR DESCRIPTION
We want to allow `unproject_layout` to be called in cases where the "original form" may be ``None`` (i.e. no column optimization occurred or it maybe failed). In these cases just return the layout.