### PR TITLE
feat: add mock-able `AwkwardTreeReductionLayer` class

### DIFF
--- a/src/dask_awkward/layers/__init__.py
+++ b/src/dask_awkward/layers/__init__.py
@@ -2,6 +2,12 @@ from dask_awkward.layers.layers import (
     AwkwardBlockwiseLayer,
     AwkwardInputLayer,
     AwkwardMaterializedLayer,
+    AwkwardTreeReductionLayer,
 )
 
-__all__ = ("AwkwardInputLayer", "AwkwardBlockwiseLayer", "AwkwardMaterializedLayer")
+__all__ = (
+    "AwkwardInputLayer",
+    "AwkwardBlockwiseLayer",
+    "AwkwardMaterializedLayer",
+    "AwkwardTreeReductionLayer",
+)

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from dask.blockwise import Blockwise, BlockwiseDepDict, blockwise_token
 from dask.highlevelgraph import MaterializedLayer
+from dask.layers import DataFrameTreeReduction
 
 from dask_awkward.utils import LazyInputsDict
 
@@ -228,3 +229,20 @@ class AwkwardMaterializedLayer(MaterializedLayer):
 
         # failed to cull during column opt
         return self, None
+
+
+class AwkwardTreeReductionLayer(DataFrameTreeReduction):
+    def mock(self):
+        return (
+            AwkwardTreeReductionLayer(
+                name=self.name,
+                name_input=self.name_input,
+                npartitions_input=1,
+                concat_func=self.concat_func,
+                tree_node_func=self.tree_node_func,
+                finalize_func=self.finalize_func,
+                split_every=self.split_every,
+                tree_node_name=self.tree_node_name,
+            ),
+            None,
+        )

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1608,7 +1608,7 @@ def total_reduction_to_scalar(
     comb_kwargs: dict[str, Any] | None = None,
     agg_kwargs: dict[str, Any] | None = None,
 ) -> Scalar:
-    from dask.layers import DataFrameTreeReduction
+    from dask_awkward.layers import AwkwardTreeReductionLayer
 
     chunked_kwargs = chunked_kwargs or {}
     token = token or tokenize(
@@ -1649,7 +1649,7 @@ def total_reduction_to_scalar(
     else:
         pass
 
-    dftr = DataFrameTreeReduction(
+    trl = AwkwardTreeReductionLayer(
         name=name_agg,
         name_input=chunked_result.name,
         npartitions_input=chunked_result.npartitions,
@@ -1661,7 +1661,7 @@ def total_reduction_to_scalar(
     )
 
     graph = HighLevelGraph.from_collections(
-        name_agg, dftr, dependencies=(chunked_result,)
+        name_agg, trl, dependencies=(chunked_result,)
     )
     return new_scalar_object(graph, name_agg, meta=meta)
 


### PR DESCRIPTION
Discovered the need for this in for typetracer only graphs (for column opt) to work after #267.