### PR TITLE
feat: do partition compat. checks with `PartitionCompatibility` sum type

### DIFF
--- a/docs/api-inspect.rst
+++ b/docs/api-inspect.rst
@@ -6,5 +6,7 @@ Inspection
 .. autosummary::
    :toctree: generated/
 
+   partition_compatibility
+   PartitionCompatibility
    necessary_columns
    sample

--- a/src/dask_awkward/lib/__init__.py
+++ b/src/dask_awkward/lib/__init__.py
@@ -1,6 +1,11 @@
-from dask_awkward.lib.core import Array, Record, Scalar
+from dask_awkward.lib.core import Array, PartitionCompatibility, Record, Scalar
 from dask_awkward.lib.core import _type as type
-from dask_awkward.lib.core import map_partitions, typetracer_from_form
+from dask_awkward.lib.core import (
+    compatible_partitions,
+    map_partitions,
+    partition_compatibility,
+    typetracer_from_form,
+)
 from dask_awkward.lib.describe import fields
 from dask_awkward.lib.inspect import necessary_columns, sample
 from dask_awkward.lib.io.io import (

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Hashable, Mapping, Sequence
 from enum import IntEnum
 from functools import cached_property, partial
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, overload
 
 import awkward as ak
 import dask.config
@@ -2348,7 +2348,7 @@ def partition_compatibility(*args: Array) -> PartitionCompatibility:
     return PartitionCompatibility._check(*args)
 
 
-HowStrictT = Literal[1] | Literal[2] | PartitionCompatibility
+HowStrictT = Union[Literal[1], Literal[2], PartitionCompatibility]
 
 
 def compatible_partitions(

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1260,6 +1260,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         if method != "__call__":
             raise RuntimeError("Array ufunc supports only method == '__call__'")
 
+        dak_arrays = tuple(a for a in inputs if isinstance(a, Array))
+        if partition_compatibility(*dak_arrays) == PartitionCompatibility.NO:
+            raise IncompatiblePartitions(*dak_arrays)
+
         return map_partitions(
             ufunc,
             *inputs,

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2286,7 +2286,7 @@ class PartitionCompatibility(IntEnum):
     MAYBE = 2
 
     @staticmethod
-    def check(*args: Array) -> PartitionCompatibility:
+    def _check(*args: Array) -> PartitionCompatibility:
         # first check to see if all arguments have the same number of
         # partitions; this is _always_ defined.
         for arg in args[1:]:
@@ -2324,4 +2324,4 @@ class PartitionCompatibility(IntEnum):
 
 
 def partition_compatibility(*args: Array) -> PartitionCompatibility:
-    return PartitionCompatibility.check(*args)
+    return PartitionCompatibility._check(*args)

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2162,13 +2162,9 @@ def compatible_partitions(*args: Array) -> bool:
         if arg.known_divisions:
             if arg.divisions != refarr.divisions:
                 return False
-        else:
-            warnings.warn(
-                f"Collection {arg.name} has unknown divisions (but has the "
-                f"same number of partitions as {refarr.name}; it's possible "
-                "that your task graph may fail at compute time if the "
-                "divisions are actually incompatible."
-            )
+
+    # if we reach this point we consider the partitions compatible.
+
     return True
 
 

--- a/src/dask_awkward/lib/operations.py
+++ b/src/dask_awkward/lib/operations.py
@@ -7,9 +7,10 @@ from dask.highlevelgraph import HighLevelGraph
 from dask_awkward.layers import AwkwardMaterializedLayer
 from dask_awkward.lib.core import (
     Array,
-    compatible_partitions,
+    PartitionCompatibility,
     map_partitions,
     new_array_object,
+    partition_compatibility,
 )
 from dask_awkward.utils import DaskAwkwardNotImplemented, IncompatiblePartitions
 
@@ -60,7 +61,7 @@ def concatenate(
         return new_array_object(hlg, name, meta=meta, npartitions=npartitions)
 
     if axis > 0:
-        if not compatible_partitions(*arrays):
+        if partition_compatibility(*arrays) == PartitionCompatibility.NO:
             raise IncompatiblePartitions("concatenate", *arrays)
 
         fn = _ConcatenateFnAxisGT0(axis=axis)

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from dask_awkward.lib.core import Array
+
 
 T = TypeVar("T")
 
@@ -19,12 +23,12 @@ https://github.com/dask-contrib/dask-awkward."""
 
 
 class IncompatiblePartitions(ValueError):
-    def __init__(self, name, *args):
+    def __init__(self, name: str, *args: Array) -> None:
         msg = self.divisions_msg(name, *args)
         super().__init__(msg)
 
     @staticmethod
-    def divisions_msg(name: str, *args: Any) -> str:
+    def divisions_msg(name: str, *args: Array) -> str:
         msg = f"The inputs to {name} are incompatibly partitioned\n"
         for i, arg in enumerate(args):
             msg += f"- arg{i} divisions: {arg.divisions}\n"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -449,25 +449,18 @@ def test_scalar_to_delayed(daa: Array, optimize_graph: bool) -> None:
 def test_compatible_partitions(ndjson_points_file: str) -> None:
     daa1 = dak.from_json([ndjson_points_file] * 5)
     daa2 = dak.from_awkward(daa1.compute(), npartitions=4)
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(daa1, daa1)
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(daa1, daa1, daa1)
-    with pytest.warns(DeprecationWarning):
-        assert not dak.compatible_partitions(daa1, daa2)
+    assert dak.compatible_partitions(daa1, daa1)
+    assert dak.compatible_partitions(daa1, daa1, daa1)
+    assert not dak.compatible_partitions(daa1, daa2)
     daa1.eager_compute_divisions()
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(daa1, daa1)
+    assert dak.compatible_partitions(daa1, daa1)
     x = ak.Array([[1, 2, 3], [1, 2, 3], [3, 4, 5]])
     y = ak.Array([[1, 2, 3], [3, 4, 5]])
     x = dak.from_awkward(x, npartitions=2)
     y = dak.from_awkward(y, npartitions=2)
-    with pytest.warns(DeprecationWarning):
-        assert not dak.compatible_partitions(x, y)
-    with pytest.warns(DeprecationWarning):
-        assert not dak.compatible_partitions(x, x, y)
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(y, y)
+    assert not dak.compatible_partitions(x, y)
+    assert not dak.compatible_partitions(x, x, y)
+    assert dak.compatible_partitions(y, y)
 
 
 def test_compatible_partitions_after_slice() -> None:
@@ -480,15 +473,11 @@ def test_compatible_partitions_after_slice() -> None:
     assert_eq(lazy, ccrt)
 
     # sanity
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(lazy, lazy + 2)
-    with pytest.warns(DeprecationWarning):
-        assert dak.compatible_partitions(lazy, dak.num(lazy, axis=1) > 2)
+    assert dak.compatible_partitions(lazy, lazy + 2)
+    assert dak.compatible_partitions(lazy, dak.num(lazy, axis=1) > 2)
 
-    with pytest.warns(DeprecationWarning):
-        assert not dak.compatible_partitions(lazy[:-2], lazy)
-    with pytest.warns(DeprecationWarning):
-        assert not dak.compatible_partitions(lazy[:-2], dak.num(lazy, axis=1) != 3)
+    assert not dak.compatible_partitions(lazy[:-2], lazy)
+    assert not dak.compatible_partitions(lazy[:-2], dak.num(lazy, axis=1) != 3)
 
     with pytest.raises(IncompatiblePartitions, match="incompatibly partitioned"):
         (lazy[:-2] + lazy).compute()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -527,6 +527,27 @@ def test_partition_compatiblity() -> None:
     assert dak.partition_compatibility(b, c) == dak.PartitionCompatibility.NO
 
 
+def test_partition_compat_with_strictness() -> None:
+    a = ak.Array([[1, 2, 3], [0, 0, 0, 0], [5, 6, 7, 8, 9], [0, 0, 0, 0]])
+    b = dak.from_awkward(a, npartitions=2)
+    c = b[dak.sum(b, axis=1) == 0]
+    d = b[dak.sum(b, axis=1) == 6]
+
+    assert dak.compatible_partitions(c, d, how_strict=1)
+    assert dak.compatible_partitions(
+        c,
+        d,
+        how_strict=dak.PartitionCompatibility.MAYBE,
+    )
+
+    assert not dak.compatible_partitions(c, d, how_strict=2)
+    assert not dak.compatible_partitions(
+        c,
+        d,
+        how_strict=dak.PartitionCompatibility.YES,
+    )
+
+
 @pytest.mark.parametrize("meta", [5, False, [1, 2, 3]])
 def test_bad_meta_type(ndjson_points_file: str, meta: Any) -> None:
     with pytest.raises(TypeError, match="meta must be an instance of an Awkward Array"):


### PR DESCRIPTION
TL;DR

- existing `dak.compatible_partitions` gets a new argument (`how_strict`) which provides some user-definable passing criteria. (existing uses of the function are unchanged, just a new argument where the default value lines up with current behavior).
- new function `dak.partition_compatibility` along with new sum type `PartitionCompatibility` can be used for more flexibility.

---

This PR introduces a `partition_compatibility` function that returns a sum type (the new `PartitionCompatibility` enum) that can be `YES`, `NO`, or `MAYBE`. This will allow downstream code to use `MAYBE` as desired. In dask-awkward we will simply use `NO` to raise exceptions.

Any place that was original checking

```python
if not dak.compatible_partitions(a, b):
    raise IncompatiblePartitions(...)
```
can now write:
```python
if dak.partition_compatibility(a, b) == dak.PartitionCompatibility.NO:
    raise IncompatiblePartitions(...)
```
One can also use `MAYBE` to go in another direction or use [pattern matching](https://peps.python.org/pep-0636/) with 3.10

the existing `compatible_partitions` function now gets a new named argument: `how_strict` which defaults to `PartitionCompatibility.MAYBE` (or `1`) (the existing behavior before this PR), setting it to `PartitionCompatibility.YES` (or `2`) will cause the function to return `False` if we are not _absolutely_ sure of the compatibility with via known `divisions`