### PR TITLE
fix: ensure that we can `dask.compute` multiple collections simultaneously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,23 +42,19 @@ io = [
   "pyarrow",
 ]
 complete = [
-  "aiohttp",
-  "pyarrow",
+  "dask-awkward[io]",
 ]
 # `docs` and `test` are separate from user installs
 docs = [
+  "dask-awkard[complete]",
   "dask-sphinx-theme >=3.0.2",
-  "pyarrow",
   "sphinx-design",
-  "pytest >=6.0",
-  "pytest-cov >=3.0.0",
   "requests >=2.27.1",
 ]
 test = [
-  "aiohttp",
+  "dask-awkward[complete]",
   "distributed",
   "pandas",
-  "pyarrow",
   "pytest >=6.0",
   "pytest-cov >=3.0.0",
   "requests >=2.27.1",

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -378,10 +378,9 @@ def _get_column_reports(dsk: HighLevelGraph) -> dict[str, Any]:
     # be length 1; but if we are using `dask.compute` to pass in
     # multiple collections to be computed simultaneously, this list
     # will increase in length.
-    outlayers = []
-    for k, v in dependents.items():
-        if isinstance(v, set) and len(v) == 0:
-            outlayers.append((k, 0))
+    leaf_layers_keys = [
+        (k, 0) for k, v in dependents.items() if isinstance(v, set) and len(v) == 0
+    ]
 
     # now we try to compute for each possible output layer key (leaf
     # node on partition 0); this will cause the typetacer reports to
@@ -390,7 +389,7 @@ def _get_column_reports(dsk: HighLevelGraph) -> dict[str, Any]:
     try:
         for layer in hlg.layers.values():
             layer.__dict__.pop("_cached_dict", None)
-        for outlayerkey in outlayers:
+        for outlayerkey in leaf_layers_keys:
             out = get_sync(hlg, outlayerkey)
             if isinstance(out, (ak.Array, ak.Record)):
                 out.layout._touch_data(recursive=True)

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -373,7 +373,11 @@ def _get_column_reports(dsk: HighLevelGraph) -> dict[str, Any]:
     # this loop builds up what are the possible final leaf nodes by
     # inspecting the dependents dictionary. If something does not have
     # a dependent, it must be the end of a graph. These are the things
-    # we need to compute for; we only a single partition (the first).
+    # we need to compute for; we only use a single partition (the
+    # first). for a single collection `.compute()` this list will just
+    # be length 1; but if we are using `dask.compute` to pass in
+    # multiple collections to be computed simultaneously, this list
+    # will increase in length.
     outlayers = []
     for k, v in dependents.items():
         if isinstance(v, set) and len(v) == 0:

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -16,7 +16,14 @@ def test_multiple_computes(pq_points_dir) -> None:
     ds3 = dak.from_lists([[[1, 2, 3], [4, 5]], [[], [0, 0, 0]]])
 
     assert ds1.name != ds2.name
-    assert dask.compute(ds1.points.x, ds2.points.y)
-    assert dask.compute(ds1.points)
+    things1 = dask.compute(ds1.points.x, ds2.points.y)
+    things2 = dask.compute(ds1.points)
+    assert things2[0].x.tolist() == things1[0].tolist()
+
+    things3 = dask.compute(ds2.points.y, ds1.points.partitions[0])
+    assert things3[0].tolist() == things1[1].tolist()
+
+    assert len(things3[1]) < len(things3[0])
+
     things = dask.compute(ds1.points, ds2.points.x, ds2.points.y, ds1.points.y, ds3)
     assert things[-1].tolist() == ak.Array(lists[0] + lists[1]).tolist()

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import dask
+
+import dask_awkward as dak
+
+
+def test_multiple_computes(pq_points_dir) -> None:
+    ds1 = dak.from_parquet(pq_points_dir)
+    # add a columns= argument to force a new tokenize result in
+    # from_parquet so we get two unique collections.
+    ds2 = dak.from_parquet(pq_points_dir, columns=["points"])
+
+    assert ds1.name != ds2.name
+    assert dask.compute(ds1.points.x, ds2.points.y)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -13,7 +13,7 @@ def test_multiple_computes(pq_points_dir) -> None:
     ds2 = dak.from_parquet(pq_points_dir, columns=["points"])
 
     lists = [[[1, 2, 3], [4, 5]], [[], [0, 0, 0]]]
-    ds3 = dak.from_lists([[[1, 2, 3], [4, 5]], [[], [0, 0, 0]]])
+    ds3 = dak.from_lists(lists)
 
     assert ds1.name != ds2.name
     things1 = dask.compute(ds1.points.x, ds2.points.y)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import awkward as ak
 import dask
 
 import dask_awkward as dak
@@ -11,5 +12,11 @@ def test_multiple_computes(pq_points_dir) -> None:
     # from_parquet so we get two unique collections.
     ds2 = dak.from_parquet(pq_points_dir, columns=["points"])
 
+    lists = [[[1, 2, 3], [4, 5]], [[], [0, 0, 0]]]
+    ds3 = dak.from_lists([[[1, 2, 3], [4, 5]], [[], [0, 0, 0]]])
+
     assert ds1.name != ds2.name
     assert dask.compute(ds1.points.x, ds2.points.y)
+    assert dask.compute(ds1.points)
+    things = dask.compute(ds1.points, ds2.points.x, ds2.points.y, ds1.points.y, ds3)
+    assert things[-1].tolist() == ak.Array(lists[0] + lists[1]).tolist()


### PR DESCRIPTION
Fix #299 

@lgray your reproducer in #299 runs for me with this PR!

I'm surprised at how small of a code change this is w.r.t. how gnarly of a problem it seemed when I first started digging into upstream dask code 😛 