### PR TITLE
Revert `unproject_layout`'s action; use `shape_touched` in column optimization.

### DIFF
--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -421,7 +421,7 @@ def _necessary_columns(dsk: HighLevelGraph) -> dict[str, list[str]]:
     """Pair layer names with lists of necessary columns."""
     kv = {}
     for name, report in _get_column_reports(dsk).items():
-        cols = {_ for _ in report.data_touched if _ is not None}
+        cols = {_ for _ in report.data_touched + report.shape_touched if _ is not None}
         select = []
         for col in sorted(cols):
             if col == name:

--- a/src/dask_awkward/lib/unproject_layout.py
+++ b/src/dask_awkward/lib/unproject_layout.py
@@ -401,6 +401,7 @@ def unproject_layout(form: Form | None, layout: Content) -> Content:
         not appear in the projected layout will be PlaceholderArrays).
 
     """
-    if form is None:
-        return layout
-    return _unproject_layout(form, layout, layout.length, layout.backend)
+    return layout
+    # if form is None:
+    #     return layout
+    # return _unproject_layout(form, layout, layout.length, layout.backend)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -95,6 +95,7 @@ def test_json_bytes_no_delim_defined(ndjson_points_file: str) -> None:
 
 
 def test_to_and_from_dask_array(daa: dak.Array) -> None:
+    daa = dak.from_awkward(daa.compute(), npartitions=3)
     computed = ak.flatten(daa.points.x.compute())
     x = dak.flatten(daa.points.x)
     daskarr = dak.to_dask_array(x)
@@ -272,6 +273,8 @@ def test_from_lists(caa_p1: ak.Array) -> None:
 
 def test_to_dask_array(daa: dak.Array, caa: dak.Array) -> None:
     from dask.array.utils import assert_eq as da_assert_eq
+
+    daa = dak.from_awkward(daa.compute(), npartitions=4)
 
     da = dak.to_dask_array(dak.flatten(daa.points.x))
     ca = ak.to_numpy(ak.flatten(caa.points.x))


### PR DESCRIPTION
Should fix #314 and #313.

This reverts the action that unproject_layout and plugs the hole left behind by using the `shape_touched` attribute of the typetracer report. The only negative side-effect we have is converting to `dask.array.Array` is failing in tests because of a mismatch between a regular numpy array and a masked numpy array.