### PR TITLE
fix: make `unproject_layout` do nothing (just return original layout)

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -73,6 +73,13 @@ class _ArgCartesianFn:
         self.kwargs = kwargs
 
     def __call__(self, *arrays):
+        # FIXME: with proper typetracer/form rehydration support we
+        # should not need to manually touch this when it's a
+        # typetracer
+        for a in arrays:
+            if ak.backend(a) == "typetracer":
+                a.layout._touch_data(recursive=True)
+
         return ak.argcartesian(list(arrays), **self.kwargs)
 
 

--- a/src/dask_awkward/lib/unproject_layout.py
+++ b/src/dask_awkward/lib/unproject_layout.py
@@ -375,7 +375,9 @@ def _unproject_layout(form, layout, length, backend):
 
 
 def unproject_layout(form: Form | None, layout: Content) -> Content:
-    """Rehydrate a layout to include all parts of an original form.
+    """Does nothing! Currently returns the passed in layout unchanged!
+
+    Rehydrate a layout to include all parts of an original form.
 
     When we perform the necessary columns optimization we drop fields
     that are not necessary for a computed result. Sometimes we have
@@ -401,6 +403,7 @@ def unproject_layout(form: Form | None, layout: Content) -> Content:
         not appear in the projected layout will be PlaceholderArrays).
 
     """
-    if form is None:
-        return layout
-    return _unproject_layout(form, layout, layout.length, layout.backend)
+    return layout
+    # if form is None:
+    #     return layout
+    # return _unproject_layout(form, layout, layout.length, layout.backend)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -95,6 +95,8 @@ def test_json_bytes_no_delim_defined(ndjson_points_file: str) -> None:
 
 
 def test_to_and_from_dask_array(daa: dak.Array) -> None:
+    daa = dak.from_awkward(daa.compute(), npartitions=3)
+
     computed = ak.flatten(daa.points.x.compute())
     x = dak.flatten(daa.points.x)
     daskarr = dak.to_dask_array(x)
@@ -272,6 +274,8 @@ def test_from_lists(caa_p1: ak.Array) -> None:
 
 def test_to_dask_array(daa: dak.Array, caa: dak.Array) -> None:
     from dask.array.utils import assert_eq as da_assert_eq
+
+    daa = dak.from_awkward(daa.compute(), npartitions=4)
 
     da = dak.to_dask_array(dak.flatten(daa.points.x))
     ca = ak.to_numpy(ak.flatten(caa.points.x))


### PR DESCRIPTION
This reverts our form hydration feature originally added in https://github.com/dask-contrib/dask-awkward/pull/184. It appears to have triggered #313 and #314. We need more testing of the feature before it's ready.

This PR is an alternative to #317. In that PR we not only revert unproject_layout's action, but we also introduce more touching in the column optimization to make up for what unproject_layout was trying to accomplish. Unfortunately using `shape_touched` from the typetracer report causing over-touching of data.

cc @lgray 