### PR TITLE
fix: make `dak.Array` copy-able

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -654,6 +654,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             )
         )
 
+    def __reduce__(self):
+        return (Array, (self.dask, self.name, self._meta, self.divisions))
+
     @property
     def dask(self) -> HighLevelGraph:
         """High level task graph associated with the collection."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any
 
@@ -806,3 +807,8 @@ def test_dask_array_in_map_partitions(daa, caa):
     y2 = np.ones(len(x2))
     z2 = x2 + y2
     assert_eq(z1, z2)
+
+
+def test_dask_awkward_Array_copy(daa):
+    c = copy.copy(daa)
+    assert_eq(daa, c)


### PR DESCRIPTION
fix #323
