### PR TITLE
fix: better error message when no collections passed to `map_partitions`.

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1623,6 +1623,16 @@ def map_partitions(
     kwarg_flat_deps, kwarg_repacker = unpack_collections(kwargs, traverse=traverse)
     flat_deps, _ = unpack_collections(*args, *kwargs.values(), traverse=traverse)
 
+    if len(flat_deps) == 0:
+        message = (
+            "map_partitions expects at least one Dask collection instance, "
+            "you are passing non-Dask collections to dask-awkward code.\n"
+            "observed argument types:\n"
+        )
+        for arg in args:
+            message += f"- {type(arg)}"
+        raise TypeError(message)
+
     arg_flat_deps_expanded = []
     arg_repackers = []
     arg_lens_for_repackers = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -812,3 +812,11 @@ def test_dask_array_in_map_partitions(daa, caa):
 def test_dask_awkward_Array_copy(daa):
     c = copy.copy(daa)
     assert_eq(daa, c)
+
+
+def test_map_partitions_no_dask_collections_passed(caa):
+    with pytest.raises(
+        TypeError,
+        match="map_partitions expects at least one Dask collection",
+    ):
+        dak.num(caa.points.x, axis=1)


### PR DESCRIPTION
based on convsersation in IRIS-HEP slack; it's possible to call a dask-awkward version of an awkward function but pass in concrete Arrays. Before this PR we hit a confusing `IndexError` when no 
collections were found. This will raise a less confusing error
