### PR TITLE
Fix error when using from_awkward on an empty array

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -89,8 +89,11 @@ def from_awkward(
 
     """
     nrows = len(source)
-    chunksize = int(math.ceil(nrows / npartitions))
-    locs = list(range(0, nrows, chunksize)) + [nrows]
+    if nrows == 0:
+        locs = [None, None]
+    else:
+        chunksize = int(math.ceil(nrows / npartitions))
+        locs = list(range(0, nrows, chunksize)) + [nrows]
     starts = locs[:-1]
     stops = locs[1:]
     meta = typetracer_array(source)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -394,3 +394,9 @@ def test_to_dataframe_str(
     df = ak.to_dataframe(caa)
 
     assert_eq(dd, df, check_index=False)
+
+
+def test_from_awkward_empty_array() -> None:
+    c = ak.Array([])
+    a = dak.from_awkward(c, npartitions=1)
+    assert_eq(a, c)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -396,7 +396,17 @@ def test_to_dataframe_str(
     assert_eq(dd, df, check_index=False)
 
 
-def test_from_awkward_empty_array() -> None:
-    c = ak.Array([])
-    a = dak.from_awkward(c, npartitions=1)
-    assert_eq(a, c)
+def test_from_awkward_empty_array(daa) -> None:
+    # no form
+    c1 = ak.Array([])
+    assert len(c1) == 0
+    a1 = dak.from_awkward(c1, npartitions=1)
+    assert_eq(a1, c1)
+    assert len(a1) == 0
+
+    # with a form
+    c2 = ak.Array(daa.layout.form.length_zero_array(highlevel=False))
+    assert len(c2) == 0
+    a2 = dak.from_awkward(c2, npartitions=1)
+    assert len(a2) == 0
+    daa.layout.form == a2.layout.form


### PR DESCRIPTION
This change fixes the ValueError that is raised if one tries to use from_awkward on an empty awkward array. For example by executing  `dak.from_awkward(ak.Array([]), 1)`.