### PR TITLE
chore: add main API functions & classes to top level `__init__.py`

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -1,19 +1,89 @@
 from dask_awkward import config  # isort:skip; load awkward config
 
-
+from dask_awkward.lib.core import Array, PartitionCompatibility, Record, Scalar
+from dask_awkward.lib.core import _type as type
+from dask_awkward.lib.core import (
+    compatible_partitions,
+    map_partitions,
+    partition_compatibility,
+    typetracer_from_form,
+)
+from dask_awkward.lib.describe import fields
+from dask_awkward.lib.inspect import necessary_columns, sample
+from dask_awkward.lib.io.io import (
+    ImplementsFormTransformation,
+    from_awkward,
+    from_dask_array,
+    from_delayed,
+    from_lists,
+    from_map,
+    to_dask_array,
+    to_dask_bag,
+    to_dataframe,
+    to_delayed,
+)
+from dask_awkward.lib.io.json import from_json, to_json
+from dask_awkward.lib.io.parquet import from_parquet, to_parquet
+from dask_awkward.lib.operations import concatenate
+from dask_awkward.lib.reducers import (
+    all,
+    any,
+    argmax,
+    argmin,
+    corr,
+    count,
+    count_nonzero,
+    covar,
+    linear_fit,
+    max,
+    mean,
+    min,
+    moment,
+    prod,
+    ptp,
+    softmax,
+    std,
+    sum,
+    var,
+)
+from dask_awkward.lib.structure import (
+    argcartesian,
+    argcombinations,
+    argsort,
+    broadcast_arrays,
+    cartesian,
+    combinations,
+    copy,
+    drop_none,
+    fill_none,
+    firsts,
+    flatten,
+    from_regular,
+    full_like,
+    is_none,
+    isclose,
+    local_index,
+    mask,
+    nan_to_num,
+    num,
+    ones_like,
+    pad_none,
+    ravel,
+    run_lengths,
+    singletons,
+    sort,
+    strings_astype,
+    to_packed,
+    to_regular,
+    unflatten,
+    unzip,
+    values_astype,
+    where,
+    with_field,
+    with_name,
+    with_parameter,
+    without_parameters,
+    zeros_like,
+    zip,
+)
 from dask_awkward.version import __version__
-
-
-def __getattr__(value):
-    import dask_awkward.lib
-
-    return getattr(dask_awkward.lib, value)
-
-
-original = dir()
-
-
-def __dir__():
-    import dask_awkward.lib  # pragma: no cover
-
-    return original + dir(dask_awkward.lib)  # pragma: no cover


### PR DESCRIPTION
Quite a while ago we moved all parts of `dask_awkward` that import upstream `awkward` inside of a `lib` submodule and made the top level `__init__.py` use `__getattr__` to find classes and functions in `lib` on-demand. The purpose of this was to avoid importing `awkward` unnecessarily (i.e. on a remote dask scheduler). As of `dask==2023.4.0` and `distributed==2023.4.0` the scheduler is now required to have the same installed packages as the client and workers [1], so this workaround is now pointless. It will make life easier (and make finding function definitions/references in IDEs easter) if we use simple top level namespace imports.

[1] https://distributed.dask.org/en/stable/changelog.html#v2023-4-0