### PR TITLE
ci: use fetch-depth 0 to get tags for correct versioning

### DIFF
--- a/.github/workflows/uproot-main.yml
+++ b/.github/workflows/uproot-main.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Setup Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
this way we get a dask-awkward version generated that satisfies uproot