### PR TITLE
fix: xfail some parquet tests due to `item -> element` change in pyarrow 13

### DIFF
--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -17,9 +17,21 @@ _RG = random.Random(414)
 DEFAULT_SCHEDULER: Any = "sync"
 
 
-NP_LTE_1_25_0 = Version(np.__version__) >= Version("1.25.0")
-AK_GTE_2_2_3 = Version(ak.__version__) <= Version("2.2.3")
-BAD_NP_AK_MIXIN_VERSIONING = NP_LTE_1_25_0 and AK_GTE_2_2_3
+NP_GTE_1_25_0 = Version(np.__version__) >= Version("1.25.0")
+AK_LTE_2_2_3 = Version(ak.__version__) <= Version("2.2.3")
+BAD_NP_AK_MIXIN_VERSIONING = NP_GTE_1_25_0 and AK_LTE_2_2_3
+
+AK_LTE_2_3_3 = Version(ak.__version__) <= Version("2.3.3")
+PA_GTE_3_0_0 = False
+
+try:
+    import pyarrow as pa
+
+    PA_GTE_3_0_0 = Version(pa.__version__) >= Version("13.0.0")
+except ImportError:
+    pass
+
+BAD_PA_AK_PARQUET_VERSIONING = AK_LTE_2_3_3 and PA_GTE_3_0_0
 
 
 def assert_eq(

--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import awkward as ak
 import numpy as np
+import pyarrow as pa
 from dask.base import is_dask_collection
 from packaging.version import Version
 
@@ -22,15 +23,7 @@ AK_LTE_2_2_3 = Version(ak.__version__) <= Version("2.2.3")
 BAD_NP_AK_MIXIN_VERSIONING = NP_GTE_1_25_0 and AK_LTE_2_2_3
 
 AK_LTE_2_3_3 = Version(ak.__version__) <= Version("2.3.3")
-PA_GTE_3_0_0 = False
-
-try:
-    import pyarrow as pa
-
-    PA_GTE_3_0_0 = Version(pa.__version__) >= Version("13.0.0")
-except ImportError:
-    pass
-
+PA_GTE_3_0_0 = Version(pa.__version__) >= Version("13.0.0")
 BAD_PA_AK_PARQUET_VERSIONING = AK_LTE_2_3_3 and PA_GTE_3_0_0
 
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -13,7 +13,7 @@ import pyarrow.dataset as pad
 
 import dask_awkward as dak
 from dask_awkward.lib.io.parquet import _metadata_file_from_data_files, to_parquet
-from dask_awkward.lib.testutils import assert_eq
+from dask_awkward.lib.testutils import BAD_PA_AK_PARQUET_VERSIONING, assert_eq
 
 data = [[1, 2, 3], [4, None], None]
 arr = pa.array(data)
@@ -74,6 +74,7 @@ def test_remote_double(ignore_metadata, scan_files, split_row_groups):
     )
 
 
+@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_one_file(tmpdir, ignore_metadata, scan_files):
@@ -84,6 +85,7 @@ def test_dir_of_one_file(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data
 
 
+@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_one_file_metadata(tmpdir, ignore_metadata, scan_files):
@@ -98,6 +100,7 @@ def test_dir_of_one_file_metadata(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data
 
 
+@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_two_files(tmpdir, ignore_metadata, scan_files):
@@ -111,6 +114,7 @@ def test_dir_of_two_files(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data * 2
 
 
+@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_two_files_metadata(tmpdir, ignore_metadata, scan_files):
@@ -126,6 +130,7 @@ def test_dir_of_two_files_metadata(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data * 2
 
 
+@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 def test_columns(tmpdir):
     tmpdir = str(tmpdir)
     pad.write_dataset(ds_deep, tmpdir, format="parquet")


### PR DESCRIPTION
following our solving of #346 we can xfail failing tests based on version combinations