### PR TITLE
feat: add `bytes_with_sample` for creating bytes reading instructions

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -11,6 +11,7 @@ from awkward.types.numpytype import primitive_to_dtype
 from dask.base import flatten, tokenize
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import funcname, is_integer, parse_bytes
+from fsspec.utils import infer_compression
 
 from dask_awkward.layers import AwkwardBlockwiseLayer, AwkwardInputLayer
 from dask_awkward.layers.layers import AwkwardMaterializedLayer
@@ -601,6 +602,9 @@ def bytes_with_sample(
         if not is_integer(blocksize):
             raise TypeError("blocksize must be an integer")
         blocksize = int(blocksize)
+
+    if compression == "infer":
+        compression = infer_compression(paths[0])
 
     if blocksize is None:
         offsets = [[0]] * len(paths)

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Protocol
 
 import awkward as ak
@@ -9,7 +10,7 @@ import numpy as np
 from awkward.types.numpytype import primitive_to_dtype
 from dask.base import flatten, tokenize
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import funcname
+from dask.utils import funcname, is_integer, parse_bytes
 
 from dask_awkward.layers import AwkwardBlockwiseLayer, AwkwardInputLayer
 from dask_awkward.layers.layers import AwkwardMaterializedLayer
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from dask.bag.core import Bag as DaskBag
     from dask.dataframe.core import DataFrame as DaskDataFrame
     from dask.delayed import Delayed
+    from fsspec.core import AbstractFileSystem
 
     from dask_awkward.lib.core import Array
 
@@ -572,3 +574,114 @@ def from_map(
         )
 
     return result
+
+
+@dataclass
+class BytesReadingInstructions:
+    fs: AbstractFileSystem
+    path: str
+    compression: str | None
+    offset: int | None
+    length: int | None
+    delimiter: bytes | None
+
+
+def bytes_with_sample(
+    fs: AbstractFileSystem,
+    paths: list[str],
+    compression: str | None,
+    delimiter: bytes | None,
+    not_zero: bool,
+    blocksize: str | int,
+    sample: str | int,
+) -> tuple[list[list[BytesReadingInstructions]], bytes]:
+    if blocksize is not None:
+        if isinstance(blocksize, str):
+            blocksize = parse_bytes(blocksize)
+        if not is_integer(blocksize):
+            raise TypeError("blocksize must be an integer")
+        blocksize = int(blocksize)
+
+    if blocksize is None:
+        offsets = [[0]] * len(paths)
+        lengths = [[None]] * len(paths)
+    else:
+        offsets = []
+        lengths = []
+        for path in paths:
+            if compression is not None:
+                raise ValueError(
+                    "Cannot do chunked reads on compressed files. "
+                    "To read, set blocksize=None"
+                )
+            size = fs.info(path)["size"]
+            if size is None:
+                raise ValueError(
+                    "Backing filesystem couldn't determine file size, cannot "
+                    "do chunked reads. To read, set blocksize=None."
+                )
+
+            elif size == 0:
+                # skip empty
+                offsets.append([])
+                lengths.append([])
+            else:
+                # shrink blocksize to give same number of parts
+                if size % blocksize and size > blocksize:
+                    blocksize1 = size / (size // blocksize)
+                else:
+                    blocksize1 = blocksize
+                place = 0
+                off = [0]
+                length = []
+
+                # figure out offsets, spreading around spare bytes
+                while size - place > (blocksize1 * 2) - 1:
+                    place += blocksize1
+                    off.append(int(place))
+                    length.append(off[-1] - off[-2])
+                length.append(size - off[-1])
+
+                if not_zero:
+                    off[0] = 1
+                    length[0] -= 1
+                offsets.append(off)
+                lengths.append(length)
+
+    out = []
+    for path, offset, length in zip(paths, offsets, lengths):
+        values = [
+            BytesReadingInstructions(
+                fs,
+                path,
+                compression,
+                offs,
+                leng,
+                delimiter,
+            )
+            for offs, leng in zip(offset, length)
+        ]
+        out.append(values)
+
+    sample_size = parse_bytes(sample) if isinstance(sample, str) else sample
+    with fs.open(paths[0], compression=compression) as f:
+        # read block without seek (because we start at zero)
+        if delimiter is None:
+            sample_bytes = f.read(sample_size)
+        else:
+            sample_buff = f.read(sample_size)
+            while True:
+                new = f.read(sample_size)
+                if not new:
+                    break
+                if delimiter in new:
+                    sample_buff = sample_buff + new.split(delimiter, 1)[0] + delimiter
+                    break
+                sample_buff = sample_buff + new
+            sample_bytes = sample_buff
+
+    rfind = sample_bytes.rfind(delimiter)
+    if rfind > 0:
+        sample_bytes = sample_bytes[:rfind]
+
+    return out, sample_bytes

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -415,8 +415,11 @@ def test_from_awkward_empty_array(daa) -> None:
 
 
 @pytest.mark.parametrize("sample", [False, 28])
+@pytest.mark.parametrize("not_zero", [True, False])
 def test_bytes_with_sample(
-    sample: int | str | bool, tmp_path_factory: pytest.TempPathFactory
+    sample: int | str | bool,
+    not_zero: bool,
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     tmppath = tmp_path_factory.mktemp("bytes_with_sample")
 
@@ -435,7 +438,7 @@ def test_bytes_with_sample(
         paths=paths,
         compression="infer",
         delimiter=b"\n",
-        not_zero=False,
+        not_zero=not_zero,
         blocksize=256,
         sample=sample,
     )
@@ -445,8 +448,9 @@ def test_bytes_with_sample(
     assert len(bytes_instructions[0]) == 2
     assert len(bytes_instructions[1]) == 2
 
-    assert bytes_instructions[0][0].offset == 0
-    assert bytes_instructions[0][0].length == 256
+    # seek until next delimieter from 1 byte forward if not_zero is True
+    assert bytes_instructions[0][0].offset == 0 if not not_zero else 1
+    assert bytes_instructions[0][0].length == 256 if not not_zero else 255
 
     assert bytes_instructions[1][1].offset == 256
     assert bytes_instructions[1][1].length == 256

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -17,7 +17,7 @@ except ImportError:
     import json  # type: ignore[no-redef]
 
 import dask_awkward as dak
-from dask_awkward.lib.io.io import bytes_with_sample
+from dask_awkward.lib.io.io import _bytes_with_sample
 from dask_awkward.lib.testutils import assert_eq
 
 
@@ -433,7 +433,7 @@ def test_bytes_with_sample(
 
     fs, _, paths = get_fs_token_paths(str(tmppath / "*.txt"))
 
-    bytes_instructions, sample_bytes = bytes_with_sample(
+    bytes_instructions, sample_bytes = _bytes_with_sample(
         fs=fs,
         paths=paths,
         compression="infer",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from dask.array.utils import assert_eq as da_assert_eq
 from dask.delayed import delayed
+from fsspec.core import get_fs_token_paths
 from numpy.typing import DTypeLike
 
 try:
@@ -16,6 +17,7 @@ except ImportError:
     import json  # type: ignore[no-redef]
 
 import dask_awkward as dak
+from dask_awkward.lib.io.io import bytes_with_sample
 from dask_awkward.lib.testutils import assert_eq
 
 
@@ -410,3 +412,46 @@ def test_from_awkward_empty_array(daa) -> None:
     a2 = dak.from_awkward(c2, npartitions=1)
     assert len(a2) == 0
     daa.layout.form == a2.layout.form
+
+
+@pytest.mark.parametrize("sample", [False, 28])
+def test_bytes_with_sample(
+    sample: int | str | bool, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    tmppath = tmp_path_factory.mktemp("bytes_with_sample")
+
+    lines1 = b"\n".join([b"a" * 127, b"b" * 127, b"c" * 127, b"d" * 128])
+    lines2 = b"\n".join([b"e" * 127, b"f" * 127, b"g" * 127, b"h" * 128])
+
+    with open(tmppath / "file1.txt", "wb") as f:
+        f.write(lines1)
+    with open(tmppath / "file2.txt", "wb") as f:
+        f.write(lines2)
+
+    fs, _, paths = get_fs_token_paths(str(tmppath / "*.txt"))
+
+    bytes_instructions, sample_bytes = bytes_with_sample(
+        fs=fs,
+        paths=paths,
+        compression="infer",
+        delimiter=b"\n",
+        not_zero=False,
+        blocksize=256,
+        sample=sample,
+    )
+
+    assert len(bytes_instructions) == 2
+
+    assert len(bytes_instructions[0]) == 2
+    assert len(bytes_instructions[1]) == 2
+
+    assert bytes_instructions[0][0].offset == 0
+    assert bytes_instructions[0][0].length == 256
+
+    assert bytes_instructions[1][1].offset == 256
+    assert bytes_instructions[1][1].length == 256
+
+    if not sample:
+        assert sample_bytes == b""
+    else:
+        assert len(sample_bytes) == 127


### PR DESCRIPTION
Pulling this out of the JSON PR (#94) because we'll also use it for `from_text` (prototype here: https://github.com/douglasdavis/dask-awkward/pull/7)