### PR TITLE
fix: remove unnecessary pyarrow import in `testutils`

### DIFF
--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import awkward as ak
 import numpy as np
-import pyarrow as pa
 from dask.base import is_dask_collection
 from packaging.version import Version
 
@@ -21,10 +20,6 @@ DEFAULT_SCHEDULER: Any = "sync"
 NP_GTE_1_25_0 = Version(np.__version__) >= Version("1.25.0")
 AK_LTE_2_2_3 = Version(ak.__version__) <= Version("2.2.3")
 BAD_NP_AK_MIXIN_VERSIONING = NP_GTE_1_25_0 and AK_LTE_2_2_3
-
-AK_LTE_2_3_3 = Version(ak.__version__) <= Version("2.3.3")
-PA_GTE_3_0_0 = Version(pa.__version__) >= Version("13.0.0")
-BAD_PA_AK_PARQUET_VERSIONING = AK_LTE_2_3_3 and PA_GTE_3_0_0
 
 
 def assert_eq(

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -13,7 +13,7 @@ import pyarrow.dataset as pad
 
 import dask_awkward as dak
 from dask_awkward.lib.io.parquet import _metadata_file_from_data_files, to_parquet
-from dask_awkward.lib.testutils import BAD_PA_AK_PARQUET_VERSIONING, assert_eq
+from dask_awkward.lib.testutils import assert_eq
 
 data = [[1, 2, 3], [4, None], None]
 arr = pa.array(data)
@@ -74,7 +74,6 @@ def test_remote_double(ignore_metadata, scan_files, split_row_groups):
     )
 
 
-@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_one_file(tmpdir, ignore_metadata, scan_files):
@@ -85,7 +84,6 @@ def test_dir_of_one_file(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data
 
 
-@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_one_file_metadata(tmpdir, ignore_metadata, scan_files):
@@ -100,7 +98,6 @@ def test_dir_of_one_file_metadata(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data
 
 
-@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_two_files(tmpdir, ignore_metadata, scan_files):
@@ -114,7 +111,6 @@ def test_dir_of_two_files(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data * 2
 
 
-@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 @pytest.mark.parametrize("ignore_metadata", [True, False])
 @pytest.mark.parametrize("scan_files", [True, False])
 def test_dir_of_two_files_metadata(tmpdir, ignore_metadata, scan_files):
@@ -130,7 +126,6 @@ def test_dir_of_two_files_metadata(tmpdir, ignore_metadata, scan_files):
     assert arr["arr"].compute().to_list() == data * 2
 
 
-@pytest.mark.xfail(BAD_PA_AK_PARQUET_VERSIONING, reason="parquet item vs element")
 def test_columns(tmpdir):
     tmpdir = str(tmpdir)
     pad.write_dataset(ds_deep, tmpdir, format="parquet")


### PR DESCRIPTION
fix #364
