### PR TITLE
feat(draft): `dask_awkward.to_rdataframe`

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -758,25 +758,29 @@ def to_rdataframe(
     flatlist_as_rvec: bool = True,
     optimize_graph: bool = False,
 ):
+    import dask
+
+    if optimize_graph:
+        (arrays,) = dask.optimize(arrays)
     keys, colls = [], []
     for k, coll in arrays.items():
         keys.append(k)
-        if optimize_graph:
-            graph = coll.__dask_graph__()
-            dkeys = coll.__dask_keys__()
-            layer = coll.__dask_layers__()[0]
-            graph = coll.__dask_optimize__(graph, dkeys)
-            graph = HighLevelGraph.from_collections(layer, graph, dependencies=())
-            colls.append(
-                new_array_object(
-                    graph,
-                    layer,
-                    meta=coll._meta,
-                    divisions=coll.divisions,
-                )
-            )
-        else:
-            colls.append(coll)
+        # if optimize_graph:
+        #     graph = coll.__dask_graph__()
+        #     dkeys = coll.__dask_keys__()
+        #     layer = coll.__dask_layers__()[0]
+        #     graph = coll.__dask_optimize__(graph, dkeys)
+        #     graph = HighLevelGraph.from_collections(layer, graph, dependencies=())
+        #     colls.append(
+        #         new_array_object(
+        #             graph,
+        #             layer,
+        #             meta=coll._meta,
+        #             divisions=coll.divisions,
+        #         )
+        #     )
+        # else:
+        colls.append(coll)
 
     fn = ToRDataFrame(keys, flatlist_as_rvec=flatlist_as_rvec)
 

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -763,9 +763,9 @@ def to_rdataframe(
         keys.append(k)
         if optimize_graph:
             graph = coll.__dask_graph__()
-            keys = coll.__dask_keys__()
+            dkeys = coll.__dask_keys__()
             layer = coll.__dask_layers__()[0]
-            graph = coll.__dask_optimize__(graph, keys)
+            graph = coll.__dask_optimize__(graph, dkeys)
             graph = HighLevelGraph.from_collections(layer, graph, dependencies=())
             colls.append(
                 new_array_object(


### PR DESCRIPTION
Fix #370

Uses map partitions and dask.delayed to support converting dictionaries of dask-awkward `Array` collections to RDataFrame.

Since awkward's `to_rdataframe` does some loading of ROOT/cppyy related things this requires importing `awkward._connect.rdataframe.to_rdataframe` before it will work. For distributed workloads I'm guessing one would need to have a worker plugin that does that same import.