### PR TITLE
ci: use `fetch-depth: 0` because uproot version checks dask-awkward

### DIFF
--- a/.github/workflows/awkward-main.yml
+++ b/.github/workflows/awkward-main.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Conda Environment
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/pypi-tests.yml
+++ b/.github/workflows/pypi-tests.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: setup Python ${{matrix.python-version}}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
When we install `dask-awkward` we get the version from git; so we need to fetch all tags in CI to make sure uproot knows we have a compatible dask-awkward version installed.