### PR TITLE
fix: declare pyarrow optional for 3.12

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         pip install wheel
         pip install pytest-cov
-        pip install dask[complete]
+        pip install dask[array,dataframe,distributed,diagnostics]
         pip install -q --no-cache-dir -e .[complete,test]
         pytest --cov=dask_awkward --cov-report=xml
     - name: Upload Coverage to Codecov

--- a/.github/workflows/pypi-tests.yml
+++ b/.github/workflows/pypi-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: install
       run: |
         pip install pip wheel -U
-        pip install dask[complete]
+        pip install dask[array,dataframe,distributed,diagnostics]
         pip install -q --no-cache-dir .[complete,test]
         pip list
     - name: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ Homepage = "https://github.com/dask-contrib/dask-awkward"
 
 [project.optional-dependencies]
 io = [
-  "aiohttp",
-  "pyarrow",
+  "aiohttp;python_version<\"3.12\"",
+  "pyarrow;python_version<\"3.12\"",
 ]
 complete = [
   "dask-awkward[io]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Homepage = "https://github.com/dask-contrib/dask-awkward"
 [project.optional-dependencies]
 io = [
   "aiohttp",
-  "pyarrow",
+  "pyarrow;python_version<\"3.12\"",
 ]
 complete = [
   "dask-awkward[io]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Homepage = "https://github.com/dask-contrib/dask-awkward"
 [project.optional-dependencies]
 io = [
   "aiohttp",
-  "pyarrow;python_version<\"3.12\"",
+  "pyarrow",
 ]
 complete = [
   "dask-awkward[io]",


### PR DESCRIPTION
I noticed that we were failing in CI due to Arrow being installed from sdist on Python 3.12.

In future, perhaps these large binary dependencies should not be installed from source as a rule. That might be a forward-looking thing to do, we also need to just ensure we don't install PyArrow here, because it's not yet available on 3.12.

This PR changes our CI to avoid pulling in `pyarrow` via `dask`, and also ensures that our own `pyproject.toml` just skips `pyarrow` and `aiohttp` if we are on 3.12