### PR TITLE
feat: deprecate `opt_touch_all` from `map_partitions`.

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1572,7 +1572,6 @@ def partitionwise_layer(
     func: Callable,
     name: str,
     *args: Any,
-    opt_touch_all: bool = False,
     **kwargs: Any,
 ) -> AwkwardBlockwiseLayer:
     """Create a partitionwise graph layer.
@@ -1627,8 +1626,6 @@ def partitionwise_layer(
         **kwargs,
     )
     layer = AwkwardBlockwiseLayer.from_blockwise(layer)
-    if opt_touch_all:
-        layer._opt_touch_all = True
     return layer
 
 
@@ -1673,7 +1670,6 @@ def map_partitions(
     token: str | None = None,
     meta: Any | None = None,
     output_divisions: int | None = None,
-    opt_touch_all: bool = False,
     traverse: bool = True,
     **kwargs: Any,
 ) -> Array:
@@ -1711,9 +1707,6 @@ def map_partitions(
         value greater than 1 means the divisions were expanded by some
         operation. This argument is mainly for internal library
         function implementations.
-    opt_touch_all : bool
-        Touch all layers in this graph during typetracer based
-        optimization.
     traverse : bool
         Unpack basic python containers to find dask collections.
     **kwargs : Any
@@ -1795,7 +1788,6 @@ def map_partitions(
         name,
         *arg_flat_deps_expanded,
         *kwarg_flat_deps,
-        opt_touch_all=opt_touch_all,
     )
 
     if meta is None:

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1744,6 +1744,14 @@ def map_partitions(
     This is effectively the same as `d = c * a`
 
     """
+    opt_touch_all = kwargs.pop("opt_touch_all", None)
+    if opt_touch_all is not None:
+        warnings.warn(
+            "The opt_touch_all argument does nothing.\n"
+            "This warning will be removed in a future version of dask-awkward "
+            "and the function call will likely fail."
+        )
+
     token = token or tokenize(base_fn, *args, meta, **kwargs)
     label = hyphenize(label or funcname(base_fn))
     name = f"{label}-{token}"

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -1261,7 +1261,6 @@ def zip(
             *colls,
             label="zip",
             meta=meta,
-            opt_touch_all=True,
         )
 
     elif isinstance(arrays, Sequence):


### PR DESCRIPTION
The `opt_touch_all` argument to `map_partitions` was added to make layers manually touchable (that is, tell the optimization code to not rely on the typetracer graph for touching in that layer, just touch all awkward data at that point). This allowed us to workaround operations where automatic typetracer touching wasn't working. 

It was only used with `dak.zip`, but with the work on upstream typetracer and the optimization refactor here in dask-awkward, I think we're in a place now where we don't need it.

It's currently used in coffea, see: https://github.com/CoffeaTeam/coffea/issues/915