### PR TITLE
feat!: add `Scalar` binary and unary ops; adjust `Scalar.__getattr__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.10.0
+  rev: 23.10.1
   hooks:
   - id: black
     language_version: python3
@@ -24,7 +24,7 @@ repos:
     - --target-version=py312
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.1
+  rev: v0.1.2
   hooks:
   - id: ruff
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -37,13 +37,9 @@ from dask.context import globalmethod
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
 from dask.threaded import get as threaded_get
-from dask.utils import (
-    IndexCallable,
-    OperatorMethodMixin,
-    funcname,
-    is_arraylike,
-    key_split,
-)
+from dask.utils import IndexCallable
+from dask.utils import OperatorMethodMixin as DaskOperatorMethodMixin
+from dask.utils import funcname, is_arraylike, key_split
 
 from dask_awkward.layers import AwkwardBlockwiseLayer, AwkwardMaterializedLayer
 from dask_awkward.lib.optimize import all_optimizations
@@ -72,7 +68,7 @@ T = TypeVar("T")
 log = logging.getLogger(__name__)
 
 
-class Scalar(DaskMethodsMixin, OperatorMethodMixin):
+class Scalar(DaskMethodsMixin, DaskOperatorMethodMixin):
     """Single partition Dask collection representing a lazy Scalar.
 
     The class constructor is not intended for users. Instances of this

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -282,41 +282,50 @@ class Scalar(DaskMethodsMixin, DaskOperatorMethodMixin):
         return f
 
 
-def _wrap_op(op):
+def _promote_maybenones(op: Callable) -> Callable:
+    """Wrap `op` function such that MaybeNone arguments are promoted.
+
+    Typetracer graphs (i.e. what is run by our necessary buffers
+    optimization) need `MaybeNone` results to be promoted to length 1
+    typetracer arrays. MaybeNone objects don't support these ops, but
+    arrays do.
+
+    """
+
     @wraps(op)
-    def f(*args, **kwargs):
+    def f(*args):
         args = tuple(
             ak.Array(arg.content) if isinstance(arg, MaybeNone) else arg for arg in args
         )
-        result = op(*args, **kwargs)
+        result = op(*args)
         return result
 
     return f
 
 
 for op in [
-    _wrap_op(operator.abs),
-    _wrap_op(operator.neg),
-    _wrap_op(operator.pos),
-    _wrap_op(operator.invert),
-    _wrap_op(operator.add),
-    _wrap_op(operator.sub),
-    _wrap_op(operator.mul),
-    _wrap_op(operator.floordiv),
-    _wrap_op(operator.truediv),
-    _wrap_op(operator.mod),
-    _wrap_op(operator.pow),
-    _wrap_op(operator.and_),
-    _wrap_op(operator.or_),
-    _wrap_op(operator.xor),
-    _wrap_op(operator.lshift),
-    _wrap_op(operator.rshift),
-    _wrap_op(operator.eq),
-    _wrap_op(operator.ge),
-    _wrap_op(operator.gt),
-    _wrap_op(operator.ne),
-    _wrap_op(operator.le),
-    _wrap_op(operator.lt),
+    _promote_maybenones(operator.abs),
+    _promote_maybenones(operator.neg),
+    _promote_maybenones(operator.pos),
+    _promote_maybenones(operator.invert),
+    _promote_maybenones(operator.add),
+    _promote_maybenones(operator.sub),
+    _promote_maybenones(operator.mul),
+    _promote_maybenones(operator.floordiv),
+    _promote_maybenones(operator.truediv),
+    _promote_maybenones(operator.mod),
+    _promote_maybenones(operator.pow),
+    _promote_maybenones(operator.and_),
+    _promote_maybenones(operator.or_),
+    _promote_maybenones(operator.xor),
+    _promote_maybenones(operator.lshift),
+    _promote_maybenones(operator.rshift),
+    _promote_maybenones(operator.eq),
+    _promote_maybenones(operator.ge),
+    _promote_maybenones(operator.gt),
+    _promote_maybenones(operator.ne),
+    _promote_maybenones(operator.le),
+    _promote_maybenones(operator.lt),
 ]:
     Scalar._bind_operator(op)
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -232,6 +232,15 @@ class Scalar(DaskMethodsMixin, OperatorMethodMixin):
             dsk = HighLevelGraph.from_collections(layer, dsk, dependencies=())
         return Delayed(self.key, dsk, layer=layer)
 
+    def __getattr__(self, attr):
+        if attr.startswith("_"):
+            raise AttributeError
+        msg = (
+            "Attribute access on Scalars should be done after converting "
+            "the Scalar collection to delayed with the to_delayed method."
+        )
+        raise AttributeError(msg)
+
     @classmethod
     def _get_binary_operator(cls, op, inv=False):
         def f(self, other):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -141,7 +141,7 @@ def test_partitions_divisions(ndjson_points_file: str) -> None:
     assert not t1.known_divisions
     t2 = daa.partitions[1]
     assert t2.known_divisions
-    assert t2.divisions == (0, divs[2] - divs[1])  # type: ignore
+    assert t2.divisions == (0, divs[2] - divs[1])
 
 
 def test_array_rebuild(ndjson_points_file: str) -> None:
@@ -209,7 +209,9 @@ def test_scalar_getitem_getattr() -> None:
     Thing = namedtuple("Thing", "a b c")
     t = Thing(c=3, b=2, a=1)
     s = new_known_scalar(t)
-    assert s.c.compute() == t.c
+    with pytest.raises(AttributeError, match="should be done after converting"):
+        s.c.compute()
+    assert s.to_delayed().c.compute() == t.c
 
 
 @pytest.mark.parametrize(
@@ -478,7 +480,7 @@ def test_compatible_partitions_after_slice() -> None:
     assert_eq(lazy, ccrt)
 
     # sanity
-    assert dak.compatible_partitions(lazy, lazy + 2)  # type: ignore
+    assert dak.compatible_partitions(lazy, lazy + 2)
     assert dak.compatible_partitions(lazy, dak.num(lazy, axis=1) > 2)
 
     assert not dak.compatible_partitions(lazy[:-2], lazy)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import operator
 import sys
 from collections import namedtuple
 from collections.abc import Callable
@@ -212,6 +213,15 @@ def test_scalar_getitem_getattr() -> None:
     with pytest.raises(AttributeError, match="should be done after converting"):
         s.c.compute()
     assert s.to_delayed().c.compute() == t.c
+
+
+@pytest.mark.parametrize("op", [operator.add, operator.truediv, operator.mul])
+def test_scalar_binary_ops(op, daa: Array, caa: ak.Array) -> None:
+    a1 = dak.max(daa.points.x, axis=None)
+    b1 = dak.min(daa.points.y, axis=None)
+    a2 = ak.max(caa.points.x, axis=None)
+    b2 = ak.min(caa.points.y, axis=None)
+    assert_eq(op(a1, b1), op(a2, b2))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -216,12 +216,30 @@ def test_scalar_getitem_getattr() -> None:
 
 
 @pytest.mark.parametrize("op", [operator.add, operator.truediv, operator.mul])
-def test_scalar_binary_ops(op, daa: Array, caa: ak.Array) -> None:
+def test_scalar_binary_ops(op: Callable, daa: Array, caa: ak.Array) -> None:
     a1 = dak.max(daa.points.x, axis=None)
     b1 = dak.min(daa.points.y, axis=None)
     a2 = ak.max(caa.points.x, axis=None)
     b2 = ak.min(caa.points.y, axis=None)
     assert_eq(op(a1, b1), op(a2, b2))
+
+
+@pytest.mark.parametrize("op", [operator.add, operator.truediv, operator.mul])
+def test_scalar_binary_ops_other_not_dak(
+    op: Callable, daa: Array, caa: ak.Array
+) -> None:
+    a1 = dak.max(daa.points.x, axis=None)
+    b1 = dak.min(daa.points.y, axis=None)
+    a2 = ak.max(caa.points.x, axis=None)
+    b2 = ak.min(caa.points.y, axis=None)
+    assert_eq(op(a1, 5), op(a2, 5))
+
+
+@pytest.mark.parametrize("op", [operator.abs])
+def test_scalar_unary_ops(op: Callable, daa: Array, caa: ak.Array) -> None:
+    a1 = dak.max(daa.points.x, axis=None)
+    a2 = ak.max(caa.points.x, axis=None)
+    assert_eq(op(-a1), op(-a2))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -141,7 +141,7 @@ def test_partitions_divisions(ndjson_points_file: str) -> None:
     assert not t1.known_divisions
     t2 = daa.partitions[1]
     assert t2.known_divisions
-    assert t2.divisions == (0, divs[2] - divs[1])
+    assert t2.divisions == (0, divs[2] - divs[1])  # type: ignore
 
 
 def test_array_rebuild(ndjson_points_file: str) -> None:
@@ -480,7 +480,7 @@ def test_compatible_partitions_after_slice() -> None:
     assert_eq(lazy, ccrt)
 
     # sanity
-    assert dak.compatible_partitions(lazy, lazy + 2)
+    assert dak.compatible_partitions(lazy, lazy + 2)  # type: ignore
     assert dak.compatible_partitions(lazy, dak.num(lazy, axis=1) > 2)
 
     assert not dak.compatible_partitions(lazy[:-2], lazy)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -229,9 +229,7 @@ def test_scalar_binary_ops_other_not_dak(
     op: Callable, daa: Array, caa: ak.Array
 ) -> None:
     a1 = dak.max(daa.points.x, axis=None)
-    b1 = dak.min(daa.points.y, axis=None)
     a2 = ak.max(caa.points.x, axis=None)
-    b2 = ak.min(caa.points.y, axis=None)
     assert_eq(op(a1, 5), op(a2, 5))
 
 


### PR DESCRIPTION
This adds support for binary and unary operations with the `Scalar` collection, fixing #396

It also changes the existing `__getattr__` implementation on the `Scalar` object. It was there to support _any_ kind of Python Scalar object by just converting to delayed, but having this breaks IPython. We should raise an error that instructs the user to convert to delayed.