### PR TITLE
feat: support returning empty arrays in `from_map` IO function calls based on user declared exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ Homepage = "https://github.com/dask-contrib/dask-awkward"
 
 [project.optional-dependencies]
 io = [
-  "pyarrow;python_version<\"3.12\"",
+  "pyarrow",
 ]
 complete = [
   "dask-awkward[io]",

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -93,7 +93,7 @@ class IOFunctionWithMocking(ImplementsMocking, ImplementsIOFunction):
         assert self._meta is not None
         return self._meta
 
-    def mock_empty(self, backend: str = "cpu") -> AwkwardArray:
+    def mock_empty(self, backend: BackendT = "cpu") -> AwkwardArray:
         import awkward as ak
 
         if backend not in ("cpu", "jax", "cuda"):

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -2,17 +2,21 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, Union, cast
 
 from dask.blockwise import Blockwise, BlockwiseDepDict, blockwise_token
 from dask.highlevelgraph import MaterializedLayer
 from dask.layers import DataFrameTreeReduction
+from typing_extensions import TypeAlias
 
 from dask_awkward.utils import LazyInputsDict
 
 if TYPE_CHECKING:
     from awkward import Array as AwkwardArray
     from awkward._nplikes.typetracer import TypeTracerReport
+
+
+BackendT: TypeAlias = Union[Literal["cpu"], Literal["jax"], Literal["cuda"]]
 
 
 class AwkwardBlockwiseLayer(Blockwise):
@@ -55,7 +59,7 @@ class ImplementsMocking(Protocol):
     def mock(self) -> AwkwardArray:
         ...
 
-    def mock_empty(self, backend: str) -> AwkwardArray:
+    def mock_empty(self, backend: BackendT) -> AwkwardArray:
         ...
 
 

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -101,7 +101,7 @@ class IOFunctionWithMocking(ImplementsMocking, ImplementsIOFunction):
                 f"backend must be one of 'cpu', 'jax', or 'cuda', received {backend}"
             )
         return ak.to_backend(
-            self._meta.layout.form.length_zero_array(highlevel=False),
+            self.mock().layout.form.length_zero_array(highlevel=False),
             backend=backend,
             highlevel=True,
         )

--- a/src/dask_awkward/lib/io/columnar.py
+++ b/src/dask_awkward/lib/io/columnar.py
@@ -7,7 +7,11 @@ import awkward as ak
 from awkward import Array as AwkwardArray
 from awkward.forms import Form
 
-from dask_awkward.layers.layers import ImplementsIOFunction, ImplementsNecessaryColumns
+from dask_awkward.layers.layers import (
+    BackendT,
+    ImplementsIOFunction,
+    ImplementsNecessaryColumns,
+)
 from dask_awkward.lib.utils import (
     METADATA_ATTRIBUTES,
     FormStructure,
@@ -57,6 +61,13 @@ class ColumnProjectionMixin(ImplementsNecessaryColumns[FormStructure]):
 
     def mock(self: S) -> AwkwardArray:
         return ak.typetracer.typetracer_from_form(self.form, behavior=self.behavior)
+
+    def mock_empty(self: S, backend: BackendT = "cpu") -> AwkwardArray:
+        return ak.to_backend(
+            self.form.length_zero_array(highlevel=False),
+            backend,
+            highlevel=True,
+        )
 
     def prepare_for_projection(
         self: S,

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -487,7 +487,6 @@ def from_map(
     divisions: tuple[int, ...] | tuple[None, ...] | None = None,
     meta: ak.Array | None = None,
     empty_on_raise: tuple[type[BaseException], ...] | None = None,
-    behavior: dict | None = None,
     **kwargs: Any,
 ) -> Array:
     """Create an Array collection from a custom mapping.
@@ -584,11 +583,11 @@ def from_map(
     if io_func_implements_mocking(func):
         io_func = func
         array_meta = cast(ImplementsMocking, func).mock()
-    # If we know the meta, we can spoof mocking
-    elif meta is not None:
-        io_func = IOFunctionWithMocking(meta, func)
-        array_meta = meta
-    # Without `meta`, the meta will be computed by executing the graph
+    # # If we know the meta, we can spoof mocking
+    # elif meta is not None:
+    #     io_func = IOFunctionWithMocking(meta, func)
+    #     array_meta = meta
+    # # Without `meta`, the meta will be computed by executing the graph
     else:
         io_func = func
         array_meta = None
@@ -597,11 +596,6 @@ def from_map(
         io_func = return_empty_on_raise(io_func, allowed_exceptions=empty_on_raise)
 
     dsk = AwkwardInputLayer(name=name, inputs=inputs, io_func=io_func)
-
-    if behavior is not None:
-        warnings.warn(
-            "The `behavior` argument is deprecated for `from_map`, and consequently ignored."
-        )
 
     hlg = HighLevelGraph.from_collections(name, dsk)
     if divisions is not None:

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -582,12 +582,11 @@ def from_map(
     if io_func_implements_mocking(func):
         io_func = func
         array_meta = cast(ImplementsMocking, func).mock()
-    # # If we know the meta, we can spoof mocking
+    # If we know the meta, we can spoof mocking
     elif meta is not None:
-        # io_func = IOFunctionWithMocking(meta, func)
-        io_func = func
+        io_func = IOFunctionWithMocking(meta, func)
         array_meta = meta
-    # # Without `meta`, the meta will be computed by executing the graph
+    # Without `meta`, the meta will be computed by executing the graph
     else:
         io_func = func
         array_meta = None

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -13,7 +13,6 @@ from dask.base import flatten, tokenize
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import funcname, is_integer, parse_bytes
 from fsspec.utils import infer_compression
-from typing_extensions import ParamSpec
 
 from dask_awkward.layers.layers import (
     AwkwardBlockwiseLayer,
@@ -39,8 +38,6 @@ if TYPE_CHECKING:
     from fsspec.spec import AbstractFileSystem
 
     from dask_awkward.lib.core import Array
-
-P = ParamSpec("P")
 
 
 class _FromAwkwardFn:

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -471,10 +471,9 @@ def return_empty_on_raise(
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
         try:
-            result = fn(*args, **kwargs)
-            return result
+            return fn(*args, **kwargs)
         except allowed_exceptions:
-            return ak.Array(fn.form.length_zero_array(highlevel=False))
+            return fn.mock_empty()
 
     return wrapped
 

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -583,9 +583,10 @@ def from_map(
         io_func = func
         array_meta = cast(ImplementsMocking, func).mock()
     # # If we know the meta, we can spoof mocking
-    # elif meta is not None:
-    #     io_func = IOFunctionWithMocking(meta, func)
-    #     array_meta = meta
+    elif meta is not None:
+        # io_func = IOFunctionWithMocking(meta, func)
+        io_func = func
+        array_meta = meta
     # # Without `meta`, the meta will be computed by executing the graph
     else:
         io_func = func

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -115,7 +115,7 @@ class _FromListsFn:
         return ak.Array(x, behavior=self.behavior)
 
 
-def from_lists(source: list, behavior: dict | None = None) -> Array:
+def from_lists(source: list) -> Array:
     """Create an Array collection from a list of lists.
 
     Parameters
@@ -144,11 +144,10 @@ def from_lists(source: list, behavior: dict | None = None) -> Array:
     lists = list(source)
     divs = (0, *np.cumsum(list(map(len, lists))))
     return from_map(
-        _FromListsFn(behavior=behavior),
+        _FromListsFn(),
         lists,
         meta=typetracer_array(ak.Array(lists[0])),
         divisions=divs,
-        behavior=behavior,
         label="from-lists",
     )
 

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -5,7 +5,7 @@ import math
 import warnings
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Type, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import awkward as ak
 import numpy as np

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import math
-import warnings
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -474,7 +474,7 @@ def return_empty_on_raise(
             result = fn(*args, **kwargs)
             return result
         except allowed_exceptions:
-            return fn.form.length_zero_array()
+            return ak.Array(fn.form.length_zero_array(highlevel=False))
 
     return wrapped
 

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -466,7 +466,7 @@ class PackedArgCallable:
 
 def return_empty_on_raise(
     fn: Callable[P, Array],
-    allowed_exceptions: tuple[Type[BaseException], ...],
+    allowed_exceptions: tuple[type[BaseException], ...],
 ) -> Callable[P, Array]:
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
@@ -487,7 +487,7 @@ def from_map(
     token: str | None = None,
     divisions: tuple[int, ...] | tuple[None, ...] | None = None,
     meta: ak.Array | None = None,
-    empty_on_raise: tuple[Type[BaseException], ...] | None = None,
+    empty_on_raise: tuple[type[BaseException], ...] | None = None,
     behavior: dict | None = None,
     **kwargs: Any,
 ) -> Array:

--- a/src/dask_awkward/lib/testutils.py
+++ b/src/dask_awkward/lib/testutils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import awkward as ak
 import numpy as np
+from awkward.typetracer import typetracer_from_form
 from dask.base import is_dask_collection
 from packaging.version import Version
 
@@ -223,3 +224,25 @@ def unnamed_root_ds() -> Array:
         ],
     ]
     return ak.Array(ds * 3)
+
+
+class RandomFailFromListsFn:
+    def __init__(self, form):
+        self.form = form
+
+    def __call__(self, x: list) -> ak.Array:
+        n = random.randint(0, 9)
+        if n < 5:
+            raise OSError("BAD!")
+
+        return ak.Array(x)
+
+    def mock(self):
+        return typetracer_from_form(self.form)
+
+    def mock_empty(self, backend="cpu"):
+        return ak.to_backend(
+            self.form.length_zero_array(highlevel=False),
+            backend=backend,
+            highlevel=True,
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -353,7 +353,7 @@ class RandomFailFromListsFn:
     def mock(self):
         return ak.typetracer.typetracer_from_form(self.form)
 
-    def mock_empty(self, backend):
+    def mock_empty(self, backend="cpu"):
         return ak.to_backend(
             self.form.length_zero_array(highlevel=False),
             backend=backend,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -351,7 +351,15 @@ class RandomFailFromListsFn:
         return ak.Array(x)
 
     def mock(self):
-        return ak.typetracer.typetracer_from_form(self.form)
+        tt = ak.typetracer.typetracer_from_form(self.form)
+        return ak.Array(tt)
+
+    def mock_empty(self, backend: str = "cpu") -> ak.Array:
+        return ak.to_backend(
+            self.form.length_zero_array(highlevel=False),
+            backend=backend,
+            highlevel=True,
+        )
 
 
 def test_random_fail_from_lists():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -339,29 +339,9 @@ def test_bytes_with_sample(
         assert len(sample_bytes) == 127
 
 
-class RandomFailFromListsFn:
-    def __init__(self, form):
-        self.form = form
-
-    def __call__(self, x: list) -> ak.Array:
-        n = random.randint(0, 9)
-        if n < 5:
-            raise OSError("BAD!")
-
-        return ak.Array(x)
-
-    def mock(self):
-        return ak.typetracer.typetracer_from_form(self.form)
-
-    def mock_empty(self, backend="cpu"):
-        return ak.to_backend(
-            self.form.length_zero_array(highlevel=False),
-            backend=backend,
-            highlevel=True,
-        )
-
-
 def test_random_fail_from_lists():
+    from dask_awkward.lib.testutils import RandomFailFromListsFn
+
     single = [[1, 2, 3], [4, 5], [6], [], [1, 2, 3]]
     many = [single] * 30
     divs = (0, *np.cumsum(list(map(len, many))))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -162,10 +162,10 @@ def test_from_map_exceptions() -> None:
         dak.from_map(f, [1, 2], [3, 4, 5])
 
     with pytest.raises(ValueError, match="must be `callable`"):
-        dak.from_map(5, [1], [2])
+        dak.from_map(5, [1], [2])  # type: ignore
 
     with pytest.raises(ValueError, match="must be Iterable"):
-        dak.from_map(f, 1, [1, 2])
+        dak.from_map(f, 1, [1, 2])  # type: ignore
 
     with pytest.raises(ValueError, match="non-zero length"):
         dak.from_map(f, [], [], [])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -351,7 +351,7 @@ class RandomFailFromListsFn:
         return ak.Array(x)
 
     def mock(self):
-        return = ak.typetracer.typetracer_from_form(self.form)
+        return ak.typetracer.typetracer_from_form(self.form)
 
     def mock_empty(self, backend: str = "cpu") -> ak.Array:
         return ak.to_backend(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from pathlib import Path
 
 import awkward as ak
@@ -163,10 +162,10 @@ def test_from_map_exceptions() -> None:
         dak.from_map(f, [1, 2], [3, 4, 5])
 
     with pytest.raises(ValueError, match="must be `callable`"):
-        dak.from_map(5, [1], [2])  # type: ignore
+        dak.from_map(5, [1], [2])
 
     with pytest.raises(ValueError, match="must be Iterable"):
-        dak.from_map(f, 1, [1, 2])  # type: ignore
+        dak.from_map(f, 1, [1, 2])
 
     with pytest.raises(ValueError, match="non-zero length"):
         dak.from_map(f, [], [], [])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -374,6 +374,7 @@ def test_random_fail_from_lists():
         divisions=divs,
         label="from-lists",
         empty_on_raise=(OSError,),
+        empty_backend="cpu",
     )
     assert len(array.compute()) < (len(single) * len(many))
 
@@ -385,6 +386,7 @@ def test_random_fail_from_lists():
             divisions=divs,
             label="from-lists",
             empty_on_raise=(RuntimeError,),
+            empty_backend="cpu",
         )
         array.compute()
 
@@ -397,3 +399,23 @@ def test_random_fail_from_lists():
             label="from-lists",
         )
         array.compute()
+
+    with pytest.raises(ValueError, match="must be used together"):
+        array = from_map(
+            RandomFailFromListsFn(form),
+            many,
+            meta=typetracer_array(ak.Array(many[0])),
+            divisions=divs,
+            label="from-lists",
+            empty_on_raise=(OSError,),
+        )
+
+    with pytest.raises(ValueError, match="must be used together"):
+        array = from_map(
+            RandomFailFromListsFn(form),
+            many,
+            meta=typetracer_array(ak.Array(many[0])),
+            divisions=divs,
+            label="from-lists",
+            empty_backend="cpu",
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -354,7 +354,7 @@ class RandomFailFromListsFn:
         return ak.typetracer.typetracer_from_form(self.form)
 
 
-def test_random_fail_from_lists() -> Array:
+def test_random_fail_from_lists():
     single = [[1, 2, 3], [4, 5], [6], [], [1, 2, 3]]
     many = [single] * 30
     divs = (0, *np.cumsum(list(map(len, many))))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -353,7 +353,7 @@ class RandomFailFromListsFn:
     def mock(self):
         return ak.typetracer.typetracer_from_form(self.form)
 
-    def mock_empty(self, backend: str = "cpu") -> ak.Array:
+    def mock_empty(self, backend):
         return ak.to_backend(
             self.form.length_zero_array(highlevel=False),
             backend=backend,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -351,8 +351,7 @@ class RandomFailFromListsFn:
         return ak.Array(x)
 
     def mock(self):
-        tt = ak.typetracer.typetracer_from_form(self.form)
-        return ak.Array(tt)
+        return = ak.typetracer.typetracer_from_form(self.form)
 
     def mock_empty(self, backend: str = "cpu") -> ak.Array:
         return ak.to_backend(


### PR DESCRIPTION
Discussed on Slack, this is a way to give `from_map` callers the ability to provide a list of "allowed" exceptions that should just return an empty array. It requires the `io_func` to have a `form` attribute such that a correctly formed empty array can be instantiated. cc @lgray 

To use this new feature there are two requirements:

1. Write a `mock_empty` method (that takes a single argument that should be passed to `ak.to_backend`) in the class function passed to `from_map`. (The `ColumnarProjectionMixin` class in the `lib.io.columnar` module provides an example implementation).
2. pass values to the `empty_on_raise` and `empty_backend` arguments of `from_map`. `tests/test_io.py` has example `from_map` calls that includes values for these arguments
