### PR TITLE
feat: add new dask-behavior protocol

### DIFF
--- a/docs/api/behavior.rst
+++ b/docs/api/behavior.rst
@@ -1,0 +1,23 @@
+Behavior
+--------
+
+Utilities to implement array behaviors for dask-awkward arrays.
+
+
+.. currentmodule:: dask_awkward
+
+
+.. autosummary::
+   :toctree: generated/
+
+   dask_property
+
+.. autosummary::
+   :toctree: generated/
+
+   dask_method
+
+.. raw:: html
+
+   <script data-goatcounter="https://dask-awkward.goatcounter.com/count"
+           async src="//gc.zgo.at/count.js"></script>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ Table of Contents
    api/io.rst
    api/reducers.rst
    api/structure.rst
+   api/behavior.rst
 
 .. toctree::
    :maxdepth: 1

--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -13,6 +13,8 @@ from dask_awkward.lib.core import Array, PartitionCompatibility, Record, Scalar
 from dask_awkward.lib.core import _type as type
 from dask_awkward.lib.core import (
     compatible_partitions,
+    dask_method,
+    dask_property,
     map_partitions,
     partition_compatibility,
 )

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -93,19 +93,9 @@ G = TypeVar("G", bound=Callable)
 
 class dask_property(property):
     _dask_get: Callable | None = None
-    _dask_set: Callable | None = None
-    _dask_del: Callable | None = None
 
-    def dask_getter(self, func: F) -> F:
+    def dask(self, func: F) -> F:
         self._dask_get = make_dask_descriptor(func)
-        return func
-
-    def dask_setter(self, func: F) -> F:
-        self._dask_set = make_dask_descriptor(func)
-        return func
-
-    def dask_deleter(self, func: F) -> F:
-        self._dask_del = make_dask_descriptor(func)
         return func
 
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -95,15 +95,15 @@ G = TypeVar("G", bound=Callable)
 class dask_property(property):
     _dask_get: Callable | None = None
 
-    def dask(self, func: F) -> F:
+    def dask(self, func: F) -> dask_property:
         self._dask_get = make_dask_descriptor(func)
-        return func
+        return self
 
 
 def dask_method(func: F) -> F:
-    def dask(dask_func_impl: G) -> G:
+    def dask(dask_func_impl: G) -> F:
         func._dask_get = make_dask_method(dask_func_impl)  # type: ignore
-        return dask_func_impl
+        return func
 
     func.dask = dask  # type: ignore
     return func

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -226,7 +226,7 @@ def dask_property(maybe_func=None, *, no_dispatch=False):
 
 def dask_method(func: F) -> F:
     """Decorate an instance method to provide a mechanism for overriding the
-    implementation for dask-awkward arrays.
+    implementation for dask-awkward arrays via `.dask`.
 
     Parameters
     ----------

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -27,7 +27,7 @@ class Point:
     def some_property(self):
         return "this is a non-dask property"
 
-    @some_property.dask_getter
+    @some_property.dask
     def some_property_dask(self, array):
         return f"this is a dask property ({type(array).__name__})"
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import no_type_check
+
 import awkward as ak
 import numpy as np
 import pytest
@@ -35,6 +37,7 @@ class Point:
     def some_method(self):
         return None
 
+    @no_type_check
     @some_method.dask
     def some_method_dask(self, array):
         return array

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -33,6 +33,10 @@ class Point:
     def some_property_dask(self, array):
         return f"this is a dask property ({type(array).__name__})"
 
+    @dak.dask_property(no_dispatch=True)
+    def some_property_both(self):
+        return "this is a dask AND non-dask property"
+
     @dak.dask_method
     def some_method(self):
         return None
@@ -77,6 +81,12 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
 
     assert repr(daa.some_method()) == repr(daa)
     assert repr(caa.some_method()) == repr(None)
+
+    assert (
+        daa.some_property_both
+        == caa.some_property_both
+        == "this is a dask AND non-dask property"
+    )
 
 
 @pytest.mark.xfail(

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -23,12 +23,21 @@ class Point:
     def point_abs(self):
         return np.sqrt(self.x**2 + self.y**2)
 
-    @property
-    def non_dask_property(self, _dask_array_=None):
+    @dak.dask_property
+    def some_property(self):
         return "this is a non-dask property"
 
-    def non_dask_method(self, _dask_array_=None):
-        return _dask_array_
+    @some_property.dask_getter
+    def some_property_dask(self, array):
+        return f"this is a dask property ({type(array).__name__})"
+
+    @dak.dask_method
+    def some_method(self):
+        return None
+
+    @some_method.dask  # type: ignore
+    def some_method_dask(self, array):
+        return array
 
 
 @pytest.mark.xfail(
@@ -60,9 +69,11 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
 
     assert daa.behavior == caa.behavior
 
-    assert daa.non_dask_property == caa.non_dask_property
+    assert caa.some_property == "this is a non-dask property"
+    assert daa.some_property == "this is a dask property (Array)"
 
-    assert repr(daa.non_dask_method()) == repr(daa)
+    assert repr(daa.some_method()) == repr(daa)
+    assert repr(caa.some_method()) == repr(None)
 
 
 @pytest.mark.xfail(

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -35,7 +35,7 @@ class Point:
     def some_method(self):
         return None
 
-    @some_method.dask  # type: ignore
+    @some_method.dask
     def some_method_dask(self, array):
         return array
 
@@ -83,18 +83,6 @@ def test_property_behavior(daa_p1: dak.Array, caa_p1: ak.Array) -> None:
 def test_nonexistent_behavior(daa_p1: dak.Array, daa_p2: dak.Array) -> None:
     daa1 = dak.with_name(daa_p1["points"], "Point", behavior=behaviors)
     daa2 = daa_p2
-
-    with pytest.raises(
-        AttributeError,
-        match="Method doesnotexist is not available to this collection",
-    ):
-        daa1._call_behavior_method("doesnotexist", daa2)
-
-    with pytest.raises(
-        AttributeError,
-        match="Property doesnotexist is not available to this collection",
-    ):
-        daa1._call_behavior_property("doesnotexist")
 
     # in this case the field check is where we raise
     with pytest.raises(AttributeError, match="distance not in fields"):


### PR DESCRIPTION
This PR is a suggestion for replacing `_dask_array_` with an extension to the descriptor protocol, namely `_dask_get`, `_dask_set`, etc.

The motivations for this are to avoid reserving a name within the function signatures, keep property descriptors looking like property descriptors, and to avoid the need to compute the function signature.

Unfortunately, if the fallback case of using `map_partitions` were implemented naively, we'd need to support a collection type that represents an `Any` type. As this isn't feasible, this PR uses a heuristic (as we already do) to determine whether the descriptor represents a method (in which case, delaying the call to map_partitions). The heuristic that I chose is to test whether the resolved attribute is `callable`.

If we are interested in this PR, then I'd probably want to add a fallback for coffea, unless they want to sync up again with coffea's latest release.

@lgray @douglasdavis 