### PR TITLE
fix: `dak.copy` should copy metadata

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -316,10 +316,15 @@ def combinations(
 
 @borrow_docstring(ak.copy)
 def copy(array: Array) -> Array:
+    # Make a copy of meta, but don't try and copy the layout;
+    # dask-awkward's copy is metadata-only
+    old_meta = array._meta
+    new_meta = ak.Array(old_meta.layout, behavior=deepcopy(old_meta._behavior))
+
     return Array(
         array._dask,
         array._name,
-        deepcopy(array._meta),
+        new_meta,
         array._divisions,
     )
 

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
+from copy import deepcopy
 from numbers import Number
 from typing import TYPE_CHECKING, Any
 
@@ -315,7 +316,12 @@ def combinations(
 
 @borrow_docstring(ak.copy)
 def copy(array: Array) -> Array:
-    return array
+    return Array(
+        array._dask,
+        array._name,
+        deepcopy(array._meta),
+        array._divisions,
+    )
 
 
 class _FillNoneFn:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -388,11 +388,8 @@ def test_sort(daa, caa, ascending):
 
 
 def test_copy(daa):
-    with pytest.raises(
-        DaskAwkwardNotImplemented,
-        match="This function is not necessary in the context of dask-awkward.",
-    ):
-        dak.copy(daa)
+    result = dak.copy(daa)
+    assert result._meta is not daa._meta
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
My recent change to `dak.copy` made it an identity. Whilst that's useful _at the buffer level_ (dask-awkward has only pure functions at the user level) we still want to copy the metadata. This will become _more_ important with `Array.attrs`.