### PR TITLE
feat: add computable report when graceful-read-failure is active in `from_map`

### DIFF
--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -107,13 +107,13 @@ class IOFunctionWithMocking(ImplementsMocking, ImplementsIOFunction):
         )
 
 
-def io_func_reor_wrapped(func: ImplementsIOFunction) -> bool:
-    return hasattr(func, "__reor_wrapped__")
+def io_func_rer_wrapped(func: ImplementsIOFunction) -> bool:
+    return hasattr(func, "__rer_wrapped__")
 
 
 def maybe_unwrap(func: Callable) -> Callable:
-    if io_func_reor_wrapped(func):
-        return func.__reor_wrapped__  # type: ignore
+    if io_func_rer_wrapped(func):
+        return func.__rer_wrapped__  # type: ignore
     return func
 
 
@@ -242,7 +242,7 @@ class AwkwardInputLayer(AwkwardBlockwiseLayer):
             ImplementsProjection, fn
         ).prepare_for_projection()
 
-        if io_func_reor_wrapped(self.io_func):
+        if io_func_rer_wrapped(self.io_func):
             new_return = (new_meta_array, type(new_meta_array)([]))
         else:
             new_return = new_meta_array
@@ -267,16 +267,8 @@ class AwkwardInputLayer(AwkwardBlockwiseLayer):
         fn = maybe_unwrap(self.io_func)
         io_func = cast(ImplementsProjection, fn).project(report=report, state=state)
 
-        if io_func_reor_wrapped(self.io_func):
-            from dask_awkward.lib.io.io import return_empty_on_raise
-
-            io_func = return_empty_on_raise(
-                io_func,
-                allowed_exceptions=self.io_func.allowed_exceptions,  # type: ignore
-                backend=self.io_func.backend,  # type: ignore
-                success_callback=self.io_func.success_callback,  # type: ignore
-                failure_callback=self.io_func.failure_callback,  # type: ignore
-            )
+        if io_func_rer_wrapped(self.io_func):
+            io_func = self.io_func.recreate(io_func)  # type: ignore
 
         return AwkwardInputLayer(
             name=self.name,

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -113,7 +113,7 @@ def io_func_reor_wrapped(func: ImplementsIOFunction) -> bool:
 
 def maybe_unwrap(func: Callable) -> Callable:
     if io_func_reor_wrapped(func):
-        return func.__reor_wrapped__
+        return func.__reor_wrapped__  # type: ignore
     return func
 
 
@@ -272,10 +272,10 @@ class AwkwardInputLayer(AwkwardBlockwiseLayer):
 
             io_func = return_empty_on_raise(
                 io_func,
-                allowed_exceptions=self.io_func.allowed_exceptions,
-                backend=self.io_func.backend,
-                success_callback=self.io_func.success_callback,
-                failure_callback=self.io_func.failure_callback,
+                allowed_exceptions=self.io_func.allowed_exceptions,  # type: ignore
+                backend=self.io_func.backend,  # type: ignore
+                success_callback=self.io_func.success_callback,  # type: ignore
+                failure_callback=self.io_func.failure_callback,  # type: ignore
             )
 
         return AwkwardInputLayer(

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -267,8 +267,7 @@ class AwkwardInputLayer(AwkwardBlockwiseLayer):
         fn = maybe_unwrap(self.io_func)
         io_func = cast(ImplementsProjection, fn).project(report=report, state=state)
 
-        is_wrapped = hasattr(self.io_func, "__reor_wrapped__")
-        if is_wrapped:
+        if io_func_reor_wrapped(self.io_func):
             from dask_awkward.lib.io.io import return_empty_on_raise
 
             io_func = return_empty_on_raise(

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -552,25 +552,6 @@ class return_empty_on_raise:
             return result, self.failure_callback(err, *args, **kwargs)
 
 
-# def return_empty_on_raise(
-#     fn: Callable[..., ak.Array],
-#     allowed_exceptions: tuple[type[BaseException], ...],
-#     backend: BackendT,
-#     success_callback: Callable[..., ak.Array],
-#     failure_callback: Callable[..., ak.Array],
-# ) -> Callable:
-#     @functools.wraps(fn)
-#     def wrapped(*args, **kwargs):
-#         try:
-#             result = fn(*args, **kwargs)
-#             return result, success_callback(*args, **kwargs)
-#         except allowed_exceptions as err:
-#             result = fn.mock_empty(backend)
-#             return result, failure_callback(err, *args, **kwargs)
-
-#     return wrapped
-
-
 @overload
 def from_map(
     func: Callable,

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -543,12 +543,12 @@ class FromMapException:
 
     def as_awkward_array(self):
         if self._exception is None:
-            return ak.Array(self._form.length_zero_array(highlevel=False))
+            return ak.Array(self._form.length_one_array(highlevel=False))
 
         return ak.Array(
             [
                 {
-                    "args": [str(a) for a in str(self._args)],
+                    "args": [str(a) for a in self._args],
                     "kwargs": [[k, str(v)] for k, v in self._kwargs.items()],
                     "exception": str(self._exception.__name__),
                     "message": str(self._error),

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -4,14 +4,11 @@ import functools
 import logging
 import math
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast, overload
 
 import awkward as ak
 import numpy as np
-from awkward.forms.listoffsetform import ListOffsetForm
-from awkward.forms.numpyform import NumpyForm
-from awkward.forms.recordform import RecordForm
 from awkward.types.numpytype import primitive_to_dtype
 from awkward.typetracer import length_zero_if_typetracer
 from dask.base import flatten, tokenize

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -721,7 +721,7 @@ def from_map(
         result = new_array_object(hlg, name, meta=array_meta, npartitions=len(inputs))
 
     if empty_on_raise and empty_backend:
-        res = result.map_partitions(first, meta=array_meta)
+        res = result.map_partitions(first, meta=array_meta, output_divisions=1)
         rep = result.map_partitions(second, meta=empty_typetracer())
         return res, rep
 

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import logging
 import math
 from collections.abc import Callable, Iterable, Mapping

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -535,12 +535,21 @@ class return_empty_on_raise:
         success_callback: Callable[..., ak.Array],
         failure_callback: Callable[..., ak.Array],
     ):
-        self.__reor_wrapped__ = fn
+        self.__rer_wrapped__ = fn
         self.fn = fn
         self.allowed_exceptions = allowed_exceptions
         self.backend = backend
         self.success_callback = success_callback
         self.failure_callback = failure_callback
+
+    def recreate(self, fn):
+        return return_empty_on_raise(
+            fn,
+            self.allowed_exceptions,
+            self.backend,
+            self.success_callback,
+            self.failure_callback,
+        )
 
     def __call__(self, *args, **kwargs):
         try:

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -547,9 +547,9 @@ def on_failure_default(
     return ak.Array(
         [
             {
-                "args": [str(a) for a in args],
-                "kwargs": [[k, str(v)] for k, v in kwargs.items()],
-                "exception": str(type(exception).__name__),
+                "args": [repr(a) for a in args],
+                "kwargs": [[k, repr(v)] for k, v in kwargs.items()],
+                "exception": type(exception).__name__,
                 "message": str(exception),
             },
         ],

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import logging
 import math
-import uuid
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast, overload

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -143,3 +143,9 @@ def first(seq: Iterable[T]) -> T:
 
     """
     return next(iter(seq))
+
+
+def second(seq: Iterable[T]) -> T:
+    the_iter = iter(seq)
+    next(the_iter)
+    return next(the_iter)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -364,9 +364,14 @@ def test_random_fail_from_lists():
     assert len(array.compute()) < (len(single) * len(many))
 
     computed_report = report.compute()
-    assert len(computed_report[computed_report["args"] == "None"]) < len(
-        computed_report
-    )
+
+    # we expect the 'args' field in the report to be empty if the
+    # from_map node succeded; so we use ak.num(..., axis=1) to filter
+    # those out.
+    succ = ak.num(computed_report["args"], axis=1) == 0
+    fail = np.invert(succ)
+    assert len(computed_report[succ]) < len(computed_report)
+    assert ak.all(computed_report[fail].exception == "OSError")
 
     with pytest.raises(OSError, match="BAD"):
         array, report = from_map(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -352,7 +352,7 @@ def test_random_fail_from_lists():
     divs = (0, *np.cumsum(list(map(len, many))))
     form = ak.Array(many[0]).layout.form
 
-    array = from_map(
+    array, report = from_map(
         RandomFailFromListsFn(form),
         many,
         meta=typetracer_array(ak.Array(many[0])),
@@ -363,8 +363,13 @@ def test_random_fail_from_lists():
     )
     assert len(array.compute()) < (len(single) * len(many))
 
+    computed_report = report.compute()
+    assert len(computed_report[computed_report["args"] == "None"]) < len(
+        computed_report
+    )
+
     with pytest.raises(OSError, match="BAD"):
-        array = from_map(
+        array, report = from_map(
             RandomFailFromListsFn(form),
             many,
             meta=typetracer_array(ak.Array(many[0])),
@@ -386,7 +391,7 @@ def test_random_fail_from_lists():
         array.compute()
 
     with pytest.raises(ValueError, match="must be used together"):
-        array = from_map(
+        from_map(
             RandomFailFromListsFn(form),
             many,
             meta=typetracer_array(ak.Array(many[0])),
@@ -396,7 +401,7 @@ def test_random_fail_from_lists():
         )
 
     with pytest.raises(ValueError, match="must be used together"):
-        array = from_map(
+        from_map(
             RandomFailFromListsFn(form),
             many,
             meta=typetracer_array(ak.Array(many[0])),
@@ -416,7 +421,7 @@ def test_random_fail_from_lists():
             return self.x * args[0]
 
     with pytest.raises(ValueError, match="must implement"):
-        array = from_map(
+        from_map(
             NoMockEmpty(5),
             many,
             meta=typetracer_array(ak.Array(many[0])),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -460,8 +460,8 @@ def test_from_map_fail_with_callbacks():
         label="from-lists",
         empty_on_raise=(OSError,),
         empty_backend="cpu",
-        empty_failure_callback=fail,
-        empty_success_callback=succ,
+        on_failure=fail,
+        on_success=succ,
     )
 
     _, rep = dask.compute(array, report)


### PR DESCRIPTION
This changes the `from_map` interface to return two collections when `empty_on_raise` and `empty_backend` are both not `None`. (When those arguments are both `None` we just return a single `Array`, which has been the existing behavior until this PR, hopefully the `@overload`s show this in a clear way)

- The first returned `Array` collection is what we've always had: the lazy awkward array populated by data on disk.
- The second returned `Array` is a record array, one element per partition, that represents a report about failed reads.

After banging my head thinking of ways to handle reports inside the graph I realized it's possible for us to just make it an awkward array (instead of some new object, the rabbit hole I originally went down). I still need to check if this breaks any optimizations, but my intuition is that it shouldn't. I still wouldn't bet the farm :)

cc @lgray @agoose77 for your thoughts. This PR demonstrates the possibility, and I think it fits in nicely with the existing `uproot.iterate(..., report=True)` two-item return pattern.