### PR TITLE
feat!: raise error to eager `len` calls

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -704,6 +704,12 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     def __len__(self) -> int:
         if not self.known_divisions:
+            warnings.warn(
+                "The divisions of this collection are unknown.\n"
+                "An eager computation of the divisions will be performed. "
+                "This may be expensive.",
+                UserWarning,
+            )
             self.eager_compute_divisions()
         return self.divisions[-1]  # type: ignore
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -707,7 +707,8 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             warnings.warn(
                 "The divisions of this collection are unknown.\n"
                 "An eager computation of the divisions will be performed. "
-                "This may be expensive.",
+                "This may be expensive.\n"
+                "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length.",
                 UserWarning,
             )
             self.eager_compute_divisions()

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -705,7 +705,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     def __len__(self) -> int:
         if not self.known_divisions:
             raise NotImplementedError(
-                "Cannot determine length of collection with unknown partitions sizes without executing the graph.\n"
+                "Cannot determine length of collection with unknown partition sizes without executing the graph.\n"
                 "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length."
             )
         return self.divisions[-1]  # type: ignore

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -706,7 +706,9 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         if not self.known_divisions:
             raise NotImplementedError(
                 "Cannot determine length of collection with unknown partition sizes without executing the graph.\n"
-                "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length."
+                "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length.\n"
+                "If you want to eagerly compute the partition sizes to have the ability to call `len` on the collection"
+                ", use `.eager_compute_divisions()` on the collection."
             )
         return self.divisions[-1]  # type: ignore
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -704,14 +704,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     def __len__(self) -> int:
         if not self.known_divisions:
-            warnings.warn(
-                "The divisions of this collection are unknown.\n"
-                "An eager computation of the divisions will be performed. "
-                "This may be expensive.\n"
-                "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length.",
-                UserWarning,
+            raise NotImplementedError(
+                "Cannot determine length of collection with unknown partitions sizes without executing the graph.\n"
+                "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length."
             )
-            self.eager_compute_divisions()
         return self.divisions[-1]  # type: ignore
 
     def _shorttypestr(self, max: int = 10) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,7 +100,15 @@ def test_compute_typetracer(daa: Array) -> None:
 
 def test_len(ndjson_points_file: str) -> None:
     daa = dak.from_json([ndjson_points_file] * 2)
-    assert len(daa) == 10
+    assert not daa.known_divisions
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            "Cannot determine length of collection with unknown partitions sizes without executing the graph.\\n"
+            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
+        ),
+    ):
+        assert len(daa) == 10
 
 
 def test_meta_exists(daa: Array) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,6 +109,9 @@ def test_len(ndjson_points_file: str) -> None:
         ),
     ):
         assert len(daa) == 10
+    daa.eager_compute_divisions()
+    assert daa.known_divisions
+    assert len(daa) == 10
 
 
 def test_meta_exists(daa: Array) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -105,7 +105,9 @@ def test_len(ndjson_points_file: str) -> None:
         NotImplementedError,
         match=(
             "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
-            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
+            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length.\\n"
+            "If you want to eagerly compute the partition sizes to have the ability to call `len` on the collection"
+            ", use `\\.eager_compute_divisions\\(\\)` on the collection."
         ),
     ):
         assert len(daa) == 10

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,7 +111,7 @@ def test_len(ndjson_points_file: str) -> None:
         assert len(daa) == 10
     daa.eager_compute_divisions()
     assert daa.known_divisions
-    assert len(daa) == 10
+    assert len(daa) == 10  # type: ignore
 
 
 def test_meta_exists(daa: Array) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -104,7 +104,7 @@ def test_len(ndjson_points_file: str) -> None:
     with pytest.raises(
         NotImplementedError,
         match=(
-            "Cannot determine length of collection with unknown partitions sizes without executing the graph.\\n"
+            "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
             "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
         ),
     ):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -284,7 +284,7 @@ def test_from_awkward_empty_array(daa: dak.Array) -> None:
     assert not a1.known_divisions
     a1.eager_compute_divisions()
     assert a1.known_divisions
-    assert len(a1) == 0
+    assert len(a1) == 0  # type: ignore
 
     # with a form
     c2 = ak.typetracer.length_zero_if_typetracer(daa.layout)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -281,12 +281,18 @@ def test_from_awkward_empty_array(daa: dak.Array) -> None:
     assert len(c1) == 0
     a1 = dak.from_awkward(c1, npartitions=1)
     assert_eq(a1, c1)
+    assert not a1.known_divisions
+    a1.eager_compute_divisions()
+    assert a1.known_divisions
     assert len(a1) == 0
 
     # with a form
     c2 = ak.typetracer.length_zero_if_typetracer(daa.layout)
     assert len(c2) == 0
     a2 = dak.from_awkward(c2, npartitions=1)
+    assert not a2.known_divisions
+    a2.eager_compute_divisions()
+    assert a2.known_divisions
     assert len(a2) == 0
     daa.layout.form == a2.layout.form
 

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -58,6 +58,16 @@ def concrete_data(json_data_dir: Path) -> ak.Array:
 def test_json_sanity(json_data_dir: Path, concrete_data: ak.Array) -> None:
     source = os.path.join(str(json_data_dir))
     ds = dak.from_json(source)
+    assert not ds.known_divisions
+    with pytest.raises(
+        NotImplementedError,
+        match=(
+            "Cannot determine length of collection with unknown partitions sizes without executing the graph.\\n"
+            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
+        ),
+    ):
+        assert ds
+    ds.eager_compute_divisions()
     assert ds
 
     assert_eq(ds, concrete_data)

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -63,7 +63,9 @@ def test_json_sanity(json_data_dir: Path, concrete_data: ak.Array) -> None:
         NotImplementedError,
         match=(
             "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
-            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
+            "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length.\\n"
+            "If you want to eagerly compute the partition sizes to have the ability to call `len` on the collection"
+            ", use `\\.eager_compute_divisions\\(\\)` on the collection."
         ),
     ):
         assert ds

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -62,7 +62,7 @@ def test_json_sanity(json_data_dir: Path, concrete_data: ak.Array) -> None:
     with pytest.raises(
         NotImplementedError,
         match=(
-            "Cannot determine length of collection with unknown partitions sizes without executing the graph.\\n"
+            "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
             "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length."
         ),
     ):


### PR DESCRIPTION
I've seen new users not immediately understanding that `len` calls are eager when divisions are unknown and wondering why their analysis code takes too long before finding out it was just a couple of `len` calls that shouldn't be there.
I was a victim of this myself. Therefore, I think a good idea would be to add a warning.