### PR TITLE
feat!: change default for `raise_failed_meta`

### DIFF
--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -2,7 +2,7 @@ awkward:
 
   # This option causes graph creation to fail if the metadata of a
   # dask-awkward Array collection cannot be determined.
-  raise-failed-meta: False
+  raise-failed-meta: True
 
   # This option is for cases where new array collections are created
   # with unknown metadata. The default setting is to compute the first

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2202,7 +2202,8 @@ def map_meta(fn: ArgsKwargsPackedFunction, *deps: Any) -> ak.Array | None:
             extras = f"function call: {fn}\n" f"metadata: {deps}\n"
             log.warning(
                 f"metadata could not be determined from operating upon the "
-                f"input array metadata. Falling back to a legacy workaround. \n"
+                f"input array metadata. Falling back to a legacy workaround — "
+                f"please report this at https://github.com/dask-contrib/dask-awkward/issues. \n"
                 f"{extras}"
             )
         pass

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2187,15 +2187,23 @@ def map_meta(fn: ArgsKwargsPackedFunction, *deps: Any) -> ak.Array | None:
         # if the metadata function call failed and raise-failed-meta
         # is True, then we want to raise the exception here.
         if dask.config.get("awkward.raise-failed-meta"):
-            log.debug("metadata determination failed: %s" % err)
+            log.debug(
+                f"metadata determination failed: {err}\n"
+                f"The config option `awkward.raise-failed-meta` to "
+                f"allow this failure was recently deprecated, and can be"
+                f"set to False to preserve this behavior before it is removed"
+            )
             raise
 
         # if the metadata function failed and we want to move on to
         # trying the length zero array calculation then we log a
         # warning and pass to the next try-except block.
         else:
+            extras = f"function call: {fn}\n" f"metadata: {deps}\n"
             log.warning(
-                "function call on just metas failed; will try length zero array technique"
+                f"metadata could not be determined from operating upon the "
+                f"input array metadata. Falling back to a legacy workaround. \n"
+                f"{extras}"
             )
         pass
     try:

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2190,8 +2190,8 @@ def map_meta(fn: ArgsKwargsPackedFunction, *deps: Any) -> ak.Array | None:
             log.debug(
                 f"metadata determination failed: {err}\n"
                 f"The config option `awkward.raise-failed-meta` to "
-                f"allow this failure was recently deprecated, and can be"
-                f"set to False to preserve this behavior before it is removed"
+                f"allow this failure was recently deprecated, and can be "
+                f"set to False to preserve this behavior before it is removed."
             )
             raise
 


### PR DESCRIPTION
@alexander-held reported seeing an obscure warning the other day. I think at this stage we're mature enough to want to see error reports from typetracer failures. This PR changes the default and tries to hide the obscure any mention of typetracer.

We should eventually remove the `length_zero_array` fallback.