### PR TITLE
feat!: change default behavior of column optimization failure to raise

### DIFF
--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -48,11 +48,11 @@ awkward:
     # exception is raised, or if nothing is done if a dask-awkward
     # specific optimization fails (right now this is only the column
     # projection optimization for determining necessary columns). The
-    # default value ("warn") will produce a warning if the
-    # optimization fails. If this option is set to "raise" and the
-    # optimization fails, an exception will be raised intead, crashing
-    # a program before an optimized compute. Finally, if the option is
-    # set to "pass" and the optimization fails, it will silently fail
-    # and the task graph continue on to be computed without
-    # dask-awkward specific optimizations.
-    on-fail: warn
+    # default value ("raise") will raise an exception, crashing a 
+    # before an optimized compute. If this option is set to "warn" 
+    # and the program optimization fails, will instead produce a 
+    # warning. Finally, if the option is set to "pass" and the 
+    # optimization fails, it will silently fail and the task graph 
+    # continue on to be computed without dask-awkward specific 
+    # optimizations.
+    on-fail: raise

--- a/src/dask_awkward/awkward.yaml
+++ b/src/dask_awkward/awkward.yaml
@@ -48,11 +48,11 @@ awkward:
     # exception is raised, or if nothing is done if a dask-awkward
     # specific optimization fails (right now this is only the column
     # projection optimization for determining necessary columns). The
-    # default value ("raise") will raise an exception, crashing a 
-    # before an optimized compute. If this option is set to "warn" 
-    # and the program optimization fails, will instead produce a 
-    # warning. Finally, if the option is set to "pass" and the 
-    # optimization fails, it will silently fail and the task graph 
-    # continue on to be computed without dask-awkward specific 
+    # default value ("raise") will raise an exception, crashing a
+    # before an optimized compute. If this option is set to "warn"
+    # and the program optimization fails, will instead produce a
+    # warning. Finally, if the option is set to "pass" and the
+    # optimization fails, it will silently fail and the task graph
+    # continue on to be computed without dask-awkward specific
     # optimizations.
     on-fail: raise


### PR DESCRIPTION
Generally a column optimization failure results from a genuine logic error in creating the dask taskgraph that users want to execute, and hiding that logic error behind continuing with a failed optimization more typically results in incorrect results as well as extremely worsened io performance for the compute task.

This PR changes the default so that we fail early, which is a better fit given the much advanced state of the typetracer interface in awkward compared to when this fall-through was written.

We should suggest that if a user is doing something that will intentionally fail the column optimization they should instead turn it off rather than attempt the optimization over and over!