### PR TITLE
fix: dak.firsts should be able to take any axis >= 1 in common case

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -402,7 +402,7 @@ def firsts(
     behavior: Mapping | None = None,
     attrs: Mapping[str, Any] | None = None,
 ) -> Any:
-    if axis == 1:
+    if axis >= 1:
         return map_partitions(
             _FirstsFn(axis=axis, highlevel=highlevel, behavior=behavior, attrs=attrs),
             array,


### PR DESCRIPTION
This is causing a failure over in https://github.com/CoffeaTeam/coffea/pull/925

Will need a dask-awkward 2023.11.5 :-)