### PR TITLE
fix: pass `keys` to column optimisation

### DIFF
--- a/src/dask_awkward/lib/inspect.py
+++ b/src/dask_awkward/lib/inspect.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 from dask.base import unpack_collections
-from dask.highlevelgraph import HighLevelGraph
 
 from dask_awkward.layers import AwkwardInputLayer
 
@@ -81,8 +80,9 @@ def report_necessary_buffers(
 
     name_to_necessary_buffers: dict[str, NecessaryBuffers | None] = {}
     for obj in collections:
-        dsk = obj if isinstance(obj, HighLevelGraph) else obj.dask
-        projection_data = o._prepare_buffer_projection(dsk)
+        dsk = obj.__dask_graph__()
+        keys = obj.__dask_keys__()
+        projection_data = o._prepare_buffer_projection(dsk, keys)
 
         # If the projection failed, or there are no input layers
         if projection_data is None:
@@ -178,8 +178,9 @@ def report_necessary_columns(
 
     name_to_necessary_columns: dict[str, frozenset | None] = {}
     for obj in collections:
-        dsk = obj if isinstance(obj, HighLevelGraph) else obj.dask
-        projection_data = o._prepare_buffer_projection(dsk)
+        dsk = obj.__dask_graph__()
+        keys = obj.__dask_keys__()
+        projection_data = o._prepare_buffer_projection(dsk, keys)
 
         # If the projection failed, or there are no input layers
         if projection_data is None:

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -287,48 +287,48 @@ def rewrite_layer_chains(dsk: HighLevelGraph, keys: Sequence[Key]) -> HighLevelG
     dependents = dsk.dependents
     all_layers = set(dsk.layers)
     while all_layers:
-        lay = all_layers.pop()
-        val = dsk.layers[lay]
-        if not isinstance(val, AwkwardBlockwiseLayer):
+        layer_key = all_layers.pop()
+        layer = dsk.layers[layer_key]
+        if not isinstance(layer, AwkwardBlockwiseLayer):
             # shortcut to avoid making comparisons
-            layers[lay] = val  # passthrough unchanged
+            layers[layer_key] = layer  # passthrough unchanged
             continue
-        children = dependents[lay]
-        chain = [lay]
-        lay0 = lay
+        children = dependents[layer_key]
+        chain = [layer_key]
+        current_layer_key = layer_key
         while (
             len(children) == 1
-            and dsk.dependencies[list(children)[0]] == {lay}
+            and dsk.dependencies[list(children)[0]] == {current_layer_key}
             and isinstance(dsk.layers[list(children)[0]], AwkwardBlockwiseLayer)
-            and len(dsk.layers[lay]) == len(dsk.layers[list(children)[0]])
-            and lay not in required_layers
+            and len(dsk.layers[current_layer_key]) == len(dsk.layers[list(children)[0]])
+            and current_layer_key not in required_layers
         ):
             # walk forwards
-            lay = list(children)[0]
-            chain.append(lay)
-            all_layers.remove(lay)
-            children = dependents[lay]
-        lay = lay0
-        parents = dsk.dependencies[lay]
+            current_layer_key = list(children)[0]
+            chain.append(current_layer_key)
+            all_layers.remove(current_layer_key)
+            children = dependents[current_layer_key]
+
+        parents = dsk.dependencies[layer_key]
         while (
             len(parents) == 1
-            and dependents[list(parents)[0]] == {lay}
+            and dependents[list(parents)[0]] == {layer_key}
             and isinstance(dsk.layers[list(parents)[0]], AwkwardBlockwiseLayer)
-            and len(dsk.layers[lay]) == len(dsk.layers[list(parents)[0]])
+            and len(dsk.layers[layer_key]) == len(dsk.layers[list(parents)[0]])
             and list(parents)[0] not in required_layers
         ):
             # walk backwards
-            lay = list(parents)[0]
-            chain.insert(0, lay)
-            all_layers.remove(lay)
-            parents = dsk.dependencies[lay]
+            layer_key = list(parents)[0]
+            chain.insert(0, layer_key)
+            all_layers.remove(layer_key)
+            parents = dsk.dependencies[layer_key]
         if len(chain) > 1:
             chains.append(chain)
             layers[chain[-1]] = copy.copy(
                 dsk.layers[chain[-1]]
             )  # shallow copy to be mutated
         else:
-            layers[lay] = val  # passthrough unchanged
+            layers[layer_key] = layer  # passthrough unchanged
 
     # do rewrite
     for chain in chains:

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import warnings
-from collections.abc import Hashable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import dask.config

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -298,13 +298,14 @@ def rewrite_layer_chains(dsk: HighLevelGraph, keys: Sequence[Key]) -> HighLevelG
         current_layer_key = layer_key
         while (
             len(children) == 1
-            and dsk.dependencies[list(children)[0]] == {current_layer_key}
-            and isinstance(dsk.layers[list(children)[0]], AwkwardBlockwiseLayer)
-            and len(dsk.layers[current_layer_key]) == len(dsk.layers[list(children)[0]])
+            and dsk.dependencies[first_child := next(iter(children))]
+            == {current_layer_key}
+            and isinstance(dsk.layers[first_child], AwkwardBlockwiseLayer)
+            and len(dsk.layers[current_layer_key]) == len(dsk.layers[first_child])
             and current_layer_key not in required_layers
         ):
             # walk forwards
-            current_layer_key = list(children)[0]
+            current_layer_key = first_child
             chain.append(current_layer_key)
             all_layers.remove(current_layer_key)
             children = dependents[current_layer_key]
@@ -312,13 +313,13 @@ def rewrite_layer_chains(dsk: HighLevelGraph, keys: Sequence[Key]) -> HighLevelG
         parents = dsk.dependencies[layer_key]
         while (
             len(parents) == 1
-            and dependents[list(parents)[0]] == {layer_key}
-            and isinstance(dsk.layers[list(parents)[0]], AwkwardBlockwiseLayer)
-            and len(dsk.layers[layer_key]) == len(dsk.layers[list(parents)[0]])
-            and list(parents)[0] not in required_layers
+            and dependents[first_parent := next(iter(parents))] == {layer_key}
+            and isinstance(dsk.layers[first_parent], AwkwardBlockwiseLayer)
+            and len(dsk.layers[layer_key]) == len(dsk.layers[first_parent])
+            and next(iter(parents)) not in required_layers
         ):
             # walk backwards
-            layer_key = list(parents)[0]
+            layer_key = first_parent
             chain.insert(0, layer_key)
             all_layers.remove(layer_key)
             parents = dsk.dependencies[layer_key]

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -38,8 +38,6 @@ def all_optimizations(dsk: Mapping, keys: Sequence[Key], **_: Any) -> Mapping:
     general optimizations from core dask.
 
     """
-    if not isinstance(keys, (list, set)):
-        keys = (keys,)  # pragma: no cover
     keys = tuple(flatten(keys))
 
     if not isinstance(dsk, HighLevelGraph):
@@ -110,7 +108,7 @@ def _prepare_buffer_projection(
 
     hlg = HighLevelGraph(projection_layers, dsk.dependencies)
 
-    minimal_keys = set()
+    minimal_keys: set[Key] = set()
     for k in keys:
         if isinstance(k, tuple) and len(k) == 2:
             minimal_keys.add((k[0], 0))

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -91,7 +91,7 @@ def input_layer_array_partition0(collection: Array) -> ak.Array:
 
     """
     with dask.config.set({"awkward.optimization.which": ["columns"]}):
-        optimized_hlg = dak_optimize(collection.dask, [])
+        optimized_hlg = dak_optimize(collection.dask, collection.keys)
         layers = list(optimized_hlg.layers)  # type: ignore
         layer_name = [name for name in layers if name.startswith("from-json")][0]
         sgc, arg = optimized_hlg[(layer_name, 0)]

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -91,7 +91,7 @@ def input_layer_array_partition0(collection: Array) -> ak.Array:
 
     """
     with dask.config.set({"awkward.optimization.which": ["columns"]}):
-        optimized_hlg = dak_optimize(collection.dask, collection.keys)
+        optimized_hlg = dak_optimize(collection.dask, collection.keys)  # type: ignore
         layers = list(optimized_hlg.layers)  # type: ignore
         layer_name = [name for name in layers if name.startswith("from-json")][0]
         sgc, arg = optimized_hlg[(layer_name, 0)]

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -78,7 +78,7 @@ def test_multiple_computes_multiple_incapsulated(daa, caa):
     assert_eq(opt4_alone, opt4)
 
 
-def test_optimization_runs_on_multiple_collections(tmp_path_factory):
+def test_optimization_runs_on_multiple_collections_gh430(tmp_path_factory):
     d = tmp_path_factory.mktemp("opt")
     array1 = ak.Array(
         [

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import awkward as ak
 import dask
+import pytest
 
 import dask_awkward as dak
 from dask_awkward.lib.testutils import assert_eq
@@ -79,6 +80,7 @@ def test_multiple_computes_multiple_incapsulated(daa, caa):
 
 
 def test_optimization_runs_on_multiple_collections_gh430(tmp_path_factory):
+    pytest.importorskip("pyarrow")
     d = tmp_path_factory.mktemp("opt")
     array1 = ak.Array(
         [


### PR DESCRIPTION
@douglasdavis I think this fixes #426.

However, I changed the type hints and made a subtle change to appease the type checker. I'm not convinced it's correct and would appreciate your input. I'll tag you at the edit site.

In our tests we assume that we can pass in `keys=[]`. Is that supposed to be the way that `dask.optimize` is used?