### PR TITLE
feat: add interface for returning reports from function classes passed to `from_map`

### DIFF
--- a/src/dask_awkward/lib/io/json.py
+++ b/src/dask_awkward/lib/io/json.py
@@ -4,7 +4,7 @@ import abc
 import logging
 import math
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import awkward as ak
 import dask
@@ -18,7 +18,13 @@ from fsspec.core import get_fs_token_paths, url_to_fs
 from fsspec.utils import infer_compression, read_block
 
 from dask_awkward.layers.layers import AwkwardMaterializedLayer
-from dask_awkward.lib.core import map_partitions, new_scalar_object, typetracer_array
+from dask_awkward.lib.core import (
+    Array,
+    Scalar,
+    map_partitions,
+    new_scalar_object,
+    typetracer_array,
+)
 from dask_awkward.lib.io.columnar import ColumnProjectionMixin
 from dask_awkward.lib.io.io import (
     _bytes_with_sample,
@@ -30,7 +36,6 @@ if TYPE_CHECKING:
     from awkward.contents.content import Content
     from fsspec.spec import AbstractFileSystem
 
-    from dask_awkward.lib.core import Array, Scalar
 
 log = logging.getLogger(__name__)
 
@@ -297,12 +302,15 @@ def _from_json_files(
         **kwargs,
     )
 
-    return from_map(
-        f,
-        paths,
-        label="from-json-files",
-        token=token,
-        meta=meta,
+    return cast(
+        Array,
+        from_map(
+            f,
+            paths,
+            label="from-json-files",
+            token=token,
+            meta=meta,
+        ),
     )
 
 
@@ -334,12 +342,15 @@ def _from_json_sopf(
         **kwargs,
     )
 
-    return from_map(
-        f,
-        paths,
-        label="from-json-sopf",
-        token=token,
-        meta=meta,
+    return cast(
+        Array,
+        from_map(
+            f,
+            paths,
+            label="from-json-sopf",
+            token=token,
+            meta=meta,
+        ),
     )
 
 
@@ -394,12 +405,15 @@ def _from_json_bytes(
         **kwargs,
     )
 
-    return from_map(
-        fn,
-        list(flatten(bytes_ingredients)),
-        label="from-json-bytes",
-        token=token,
-        meta=meta,
+    return cast(
+        Array,
+        from_map(
+            fn,
+            list(flatten(bytes_ingredients)),
+            label="from-json-bytes",
+            token=token,
+            meta=meta,
+        ),
     )
 
 

--- a/src/dask_awkward/lib/io/text.py
+++ b/src/dask_awkward/lib/io/text.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import cast
 
 import awkward as ak
 import numpy as np
@@ -12,14 +12,12 @@ from dask.core import flatten
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import infer_compression, read_block
 
+from dask_awkward.lib.core import Array
 from dask_awkward.lib.io.io import (
     _bytes_with_sample,
     _BytesReadingInstructions,
     from_map,
 )
-
-if TYPE_CHECKING:
-    from dask_awkward.lib.core import Array
 
 
 def _string_array_from_bytestring(bytestring: bytes, delimiter: bytes) -> ak.Array:
@@ -117,10 +115,13 @@ def from_text(
         )
     )
 
-    return from_map(
-        _from_text_on_block,
-        list(flatten(bytes_ingredients)),
-        label="from-text",
-        token=token,
-        meta=meta,
+    return cast(
+        Array,
+        from_map(
+            _from_text_on_block,
+            list(flatten(bytes_ingredients)),
+            label="from-text",
+            token=token,
+            meta=meta,
+        ),
     )

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -143,3 +143,9 @@ def first(seq: Iterable[T]) -> T:
 
     """
     return next(iter(seq))
+
+
+def second(seq: Iterable[T]) -> T:
+    the_iter = iter(seq)
+    next(the_iter)
+    return next(the_iter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import awkward as ak
 import fsspec
@@ -73,7 +74,7 @@ def pq_points_dir(daa: dak.Array, tmp_path_factory: pytest.TempPathFactory) -> s
 
 @pytest.fixture(scope="session")
 def daa_parquet(pq_points_dir: str) -> dak.Array:
-    return dak.from_parquet(pq_points_dir)
+    return cast(dak.Array, dak.from_parquet(pq_points_dir))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -883,6 +883,6 @@ def test_shape_only_ops(fn: Callable, tmp_path_factory: pytest.TempPathFactory) 
     p = tmp_path_factory.mktemp("zeros-like-flat")
     ak.to_parquet(a, str(p / "file.parquet"))
     lazy = dak.from_parquet(str(p))
-    result = fn(lazy.b)
+    result = fn(lazy.b)  # type: ignore
     with dask.config.set({"awkward.optimization.enabled": True}):
         result.compute()


### PR DESCRIPTION
This supersedes #415

**High level overview**: dask-awkward's `from_map` function takes a callable as the first argument (`func`). If that callable has a `return_report` property that returns ``True``, then `from_map` will return **two** collections. The first will be the `Array` collection of interest (computes to be the intended data array) and the second will be another `Array` collection that computes to some user defined thing implemented for the specific `func` that gets passed into `from_map`.