### PR TITLE
fix: pickle array attributes

### DIFF
--- a/src/dask_awkward/pickle.py
+++ b/src/dask_awkward/pickle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 __all__ = ("plugin",)
@@ -10,11 +11,42 @@ import awkward as ak
 from awkward.typetracer import PlaceholderArray
 
 
-def maybe_make_pickle_buffer(buffer: Any) -> PlaceholderArray | PickleBuffer:
+def _maybe_make_pickle_buffer(buffer: Any) -> PlaceholderArray | PickleBuffer:
     if isinstance(buffer, PlaceholderArray):
         return buffer
     else:
         return PickleBuffer(buffer)
+
+
+def _without_transient_attrs(attrs: Mapping[str, Any]) -> Mapping[str, Any]:
+    return {k: v for k, v in attrs.items() if not k.startswith("@")}
+
+
+def _unpickle_record_schema_1(
+    form_dict: dict,
+    length: Any,
+    container: Mapping[str, Any],
+    behavior: Mapping | None,
+    attrs: Mapping[str, Any] | None,
+    at: int,
+) -> ak.Record:
+    array_layout = ak.from_buffers(
+        form_dict, length, container, behavior=behavior, attrs=attrs, highlevel=False
+    )
+    layout = ak.record.Record(array_layout, at)
+    return ak.Record(layout, behavior=behavior, attrs=attrs)
+
+
+def _unpickle_array_schema_1(
+    form_dict: dict,
+    length: Any,
+    container: Mapping[str, Any],
+    behavior: Mapping | None,
+    attrs: Mapping[str, Any] | None,
+) -> ak.Array:
+    return ak.from_buffers(
+        form_dict, length, container, behavior=behavior, attrs=attrs, highlevel=True
+    )
 
 
 def pickle_record(record: ak.Record, protocol: int) -> tuple:
@@ -28,17 +60,21 @@ def pickle_record(record: ak.Record, protocol: int) -> tuple:
 
     # For pickle >= 5, we can avoid copying the buffers
     if protocol >= 5:
-        container = {k: maybe_make_pickle_buffer(v) for k, v in container.items()}
+        container = {k: _maybe_make_pickle_buffer(v) for k, v in container.items()}
 
     if record.behavior is ak.behavior:
         behavior = None
     else:
         behavior = record.behavior
 
+    if record._attrs is None:
+        attrs = record._attrs
+    else:
+        attrs = _without_transient_attrs(record._attrs)
+
     return (
-        object.__new__,
-        (ak.Record,),
-        (form.to_dict(), length, container, behavior, layout.at),
+        _unpickle_record_schema_1,
+        (form.to_dict(), length, container, behavior, attrs, layout.at),
     )
 
 
@@ -53,17 +89,21 @@ def pickle_array(array: ak.Array, protocol: int) -> tuple:
 
     # For pickle >= 5, we can avoid copying the buffers
     if protocol >= 5:
-        container = {k: maybe_make_pickle_buffer(v) for k, v in container.items()}
+        container = {k: _maybe_make_pickle_buffer(v) for k, v in container.items()}
 
     if array.behavior is ak.behavior:
         behavior = None
     else:
         behavior = array.behavior
 
+        if array._attrs is None:
+            attrs = array._attrs
+        else:
+            attrs = _without_transient_attrs(array._attrs)
+
     return (
-        object.__new__,
-        (ak.Array,),
-        (form.to_dict(), length, container, behavior),
+        _unpickle_array_schema_1,
+        (form.to_dict(), length, container, behavior, attrs),
     )
 
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -8,7 +8,11 @@ import numpy as np
 
 def test_pickle_ak_array():
     buffers = []
-    array = ak.Array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])[[0, 2]]
+    attrs = {"foo": "keep", "@foo": "drop"}
+    behavior = {("some", "behavior"): "key"}
+    array = ak.Array(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], attrs=attrs, behavior=behavior
+    )[[0, 2]]
     next_array = pickle.loads(
         pickle.dumps(array, protocol=5, buffer_callback=buffers.append), buffers=buffers
     )
@@ -27,18 +31,27 @@ def test_pickle_ak_array():
         array.layout.stops.data,
         next_array.layout.stops.data,
     )
+    assert next_array.behavior == behavior
+    assert next_array.attrs == {"foo": "keep"}
 
 
 def test_pickle_ak_record():
     buffers = []
+    attrs = {"foo": "keep", "@foo": "drop"}
+    behavior = {("some", "behavior"): "key"}
     record = ak.zip(
-        {"x": [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]}, depth_limit=1
+        {"x": [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]},
+        depth_limit=1,
+        behavior=behavior,
+        attrs=attrs,
     )[2]
     next_record = pickle.loads(
         pickle.dumps(record, protocol=5, buffer_callback=buffers.append),
         buffers=buffers,
     )
     assert record.layout.at == next_record.layout.at
+    assert next_record.behavior == behavior
+    assert next_record.attrs == {"foo": "keep"}
 
     array = ak.Array(record.layout.array)
     next_array = ak.Array(next_record.layout.array)


### PR DESCRIPTION
This PR should have been done earlier (it fell off my To-Do list!). It introduces a versioned unpickling scheme (through dedicated unpickling functions) that ensures we also serialise the `attrs` and `behavior` dictionaries. As per the semantics of `attrs`, we drop any prefixed keys.

@lgray it occurs to me that inter-worker transfer would break arrays which depend upon `@foo` keys existing in the attrs dict. I can't imagine that we would want that. Maybe we need to discuss the issue further, though this PR can merge as-is.

Closes #427