### PR TITLE
feat: add support for `Delayed` in partitionwise layer creation.

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2029,13 +2029,22 @@ def map_partitions(
         dependencies=flat_deps,
     )
 
+    dak_arrays = tuple(filter(lambda x: isinstance(x, Array), flat_deps))
+    if len(dak_arrays) == 0:
+        raise TypeError(
+            "at least one argument passed to map_partitions "
+            "should be a dask_awkward.Array collection."
+        )
+    in_npartitions = dak_arrays[0].npartitions
+    in_divisions = dak_arrays[0].divisions
+    if partition_compatibility(*dak_arrays) == PartitionCompatibility.NO:
+        raise IncompatiblePartitions("map_partitions", *dak_arrays)
+
     if output_divisions is not None:
         if output_divisions == 1:
             new_divisions = flat_deps[0].divisions
         else:
-            new_divisions = tuple(
-                map(lambda x: x * output_divisions, flat_deps[0].divisions)
-            )
+            new_divisions = tuple(map(lambda x: x * output_divisions, in_divisions))
         return new_array_object(
             hlg,
             name=name,
@@ -2047,7 +2056,7 @@ def map_partitions(
             hlg,
             name=name,
             meta=meta,
-            npartitions=flat_deps[0].npartitions,
+            npartitions=in_npartitions,
         )
 
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1830,6 +1830,8 @@ def partitionwise_layer(
         elif isinstance(arg, Scalar):
             pairs.extend([arg.name, "i"])
             numblocks[arg.name] = (1,)
+        elif isinstance(arg, Delayed):
+            pairs.extend([arg.key, None])
         elif is_dask_collection(arg):
             raise DaskAwkwardNotImplemented(
                 "Use of Array with other Dask collections is currently unsupported."

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2037,8 +2037,6 @@ def map_partitions(
         )
     in_npartitions = dak_arrays[0].npartitions
     in_divisions = dak_arrays[0].divisions
-    if partition_compatibility(*dak_arrays) == PartitionCompatibility.NO:
-        raise IncompatiblePartitions("map_partitions", *dak_arrays)
 
     if output_divisions is not None:
         if output_divisions == 1:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -930,17 +930,6 @@ def multiply(a, b, c):
 def test_map_partitions_bad_arguments():
     array1 = ak.Array([[1, 2, 3], [4], [5, 6, 7], [8]])
     array2 = ak.Array([4, 5, 6, 7])
-    dak_array1 = dak.from_awkward(array1, npartitions=2)
-    dak_array2 = dak.from_awkward(array2, npartitions=1)
-    with pytest.raises(IncompatiblePartitions):
-        result = map_partitions(
-            multiply,
-            dak_array1,
-            dak_array2,
-            a_delayed_array(),
-            meta=dak_array1._meta,
-        )
-
     with pytest.raises(TypeError, match="at least one"):
         result = map_partitions(
             multiply,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -931,7 +931,7 @@ def test_map_partitions_bad_arguments():
     array1 = ak.Array([[1, 2, 3], [4], [5, 6, 7], [8]])
     array2 = ak.Array([4, 5, 6, 7])
     with pytest.raises(TypeError, match="at least one"):
-        result = map_partitions(
+        map_partitions(
             multiply,
             a_delayed_array(),
             array1,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ from dask_awkward.lib.core import (
     calculate_known_divisions,
     compute_typetracer,
     is_typetracer,
+    map_partitions,
     meta_or_identity,
     new_array_object,
     new_known_scalar,
@@ -891,14 +892,15 @@ def test_shape_only_ops(fn: Callable, tmp_path_factory: pytest.TempPathFactory) 
 
 @delayed
 def a_delayed_array():
-    return ak.Array([1, 2])
+    return ak.Array([2, 4])
 
 
 def test_partitionwise_op_with_delayed():
     array = ak.Array([[1, 2, 3], [4], [5, 6, 7], [8]])
     dak_array = dak.from_awkward(array, npartitions=2)
-    result = dak_array.map_partitions(
+    result = map_partitions(
         operator.mul,
+        dak_array,
         a_delayed_array(),
         meta=dak_array._meta,
         output_divisions=1,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -909,3 +909,4 @@ def test_partitionwise_op_with_delayed():
             array[2:] * a_delayed_array().compute(),
         ],
     )
+    assert_eq(result, concrete_result)


### PR DESCRIPTION
Broadcasting will occur equivalently at each partition because the Delayed object is *not* partitioned (as shown in the test added in this PR).