### PR TITLE
docs: fix RTD build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # a list of builtin themes.
 #
 html_theme = "sphinx_book_theme"
+# broken see PR 451
+# html_theme = "dask_sphinx_theme
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "dask_sphinx_theme"
+html_theme = "sphinx_book_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ complete = [
 # `docs` and `test` are separate from user installs
 docs = [
   "dask-awkward[complete]",
-  "dask-sphinx-theme >=3.0.2",
+  "sphinx-book-theme",
   "sphinx-design",
   "sphinx-codeautolink",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ docs = [
   "sphinx-book-theme",
   "sphinx-design",
   "sphinx-codeautolink",
+  # broken see PR 451
+  # "dask-sphinx-theme",
 ]
 test = [
   "aiohttp;python_version<\"3.12\"",


### PR DESCRIPTION
The Dask specific Sphinx theme is breaking on RTD; this PR is meant as a temporary fall back to the non Dask branded version for now to make sure we have docs building successfully.