### PR TITLE
fix: remove over aggressive multiargument `getitem` to `map_partitions`

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -47,6 +47,7 @@ from dask_awkward.lib.optimize import all_optimizations
 from dask_awkward.utils import (
     DaskAwkwardNotImplemented,
     IncompatiblePartitions,
+    field_access_to_front,
     first,
     hyphenize,
     is_empty_slice,
@@ -1396,17 +1397,15 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         )
 
     def _getitem_tuple(self, where):
+        where = field_access_to_front(where)
         if isinstance(where[0], int):
             return self._getitem_outer_int(where)
 
-        elif isinstance(where[0], str):
+        elif isinstance(where[0], (str, list)):
             first, rest = where[0], where[1:]
             if rest:
                 return self[first][rest]
             return self[first]
-
-        elif isinstance(where[0], list):
-            return self._getitem_outer_str_or_list(where)
 
         elif isinstance(where[0], slice) and is_empty_slice(where[0]):
             return self._getitem_trivial_map_partitions(where)

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1400,7 +1400,10 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             return self._getitem_outer_int(where)
 
         elif isinstance(where[0], str):
-            return self._getitem_outer_str_or_list(where)
+            first, rest = where[0], where[1:]
+            if rest:
+                return self[first][rest]
+            return self[first]
 
         elif isinstance(where[0], list):
             return self._getitem_outer_str_or_list(where)

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -975,7 +975,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     def __len__(self) -> int:
         if not self.known_divisions:
-            raise NotImplementedError(
+            raise TypeError(
                 "Cannot determine length of collection with unknown partition sizes without executing the graph.\n"
                 "Use `dask_awkward.num(..., axis=0)` if you want a lazy Scalar of the length.\n"
                 "If you want to eagerly compute the partition sizes to have the ability to call `len` on the collection"

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1397,15 +1397,16 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
         )
 
     def _getitem_tuple(self, where):
-        where = field_access_to_front(where)
+        where, n_field_accesses = field_access_to_front(where)
+
         if isinstance(where[0], int):
             return self._getitem_outer_int(where)
 
         elif isinstance(where[0], (str, list)):
-            first, rest = where[0], where[1:]
+            first, rest = where[:n_field_accesses], where[n_field_accesses:]
             if rest:
-                return self[first][rest]
-            return self[first]
+                return self._getitem_trivial_map_partitions(first)[rest]
+            return self._getitem_trivial_map_partitions(first)
 
         elif isinstance(where[0], slice) and is_empty_slice(where[0]):
             return self._getitem_trivial_map_partitions(where)

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
+from collections.abc import Sequence
 
 from typing_extensions import ParamSpec
 

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -151,12 +151,12 @@ def second(seq: Iterable[T]) -> T:
     return next(the_iter)
 
 
-def field_access_like(entry: Any) -> bool:
+def not_field_access_like(entry: Any) -> bool:
     if isinstance(entry, str):
-        return True
+        return False
     if isinstance(entry, (list, tuple)) and all(isinstance(x, str) for x in entry):
-        return True
-    return False
+        return False
+    return True
 
 
 def field_access_to_front(seq: Sequence[Any]) -> tuple[tuple[Any, ...], int]:
@@ -197,12 +197,6 @@ def field_access_to_front(seq: Sequence[Any]) -> tuple[tuple[Any, ...], int]:
     2
 
     """
-    new_seq: list[Any] = []
-    n_front = 0
-    for entry in seq:
-        if field_access_like(entry):
-            new_seq.insert(n_front, entry)
-            n_front += 1
-        else:
-            new_seq.append(entry)
-    return tuple(new_seq), n_front
+    new_args = tuple(sorted(seq, key=not_field_access_like))
+    n_field_accesses = sum(map(lambda x: not not_field_access_like(x), new_args))
+    return new_args, n_field_accesses

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
-from collections.abc import Sequence
 
 from typing_extensions import ParamSpec
 
@@ -160,7 +159,7 @@ def field_access_like(entry: Any) -> bool:
     return False
 
 
-def field_access_to_front(seq: Sequence[Any]) -> tuple[Any, ...]:
+def field_access_to_front(seq: Sequence[Any]) -> tuple[tuple[Any, ...], int]:
     new_seq = []
     n_front = 0
     for entry in seq:
@@ -169,4 +168,4 @@ def field_access_to_front(seq: Sequence[Any]) -> tuple[Any, ...]:
             n_front += 1
         else:
             new_seq.append(entry)
-    return tuple(new_seq)
+    return tuple(new_seq), n_front

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -197,7 +197,7 @@ def field_access_to_front(seq: Sequence[Any]) -> tuple[tuple[Any, ...], int]:
     2
 
     """
-    new_seq = []
+    new_seq: list[Any] = []
     n_front = 0
     for entry in seq:
         if field_access_like(entry):

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -152,6 +152,35 @@ def second(seq: Iterable[T]) -> T:
 
 
 def not_field_access_like(entry: Any) -> bool:
+    """Test field-access-likeness of a getitem argument.
+
+    Field accesses are strings or lists-of-strings, for example:
+
+    - ``"foo"``
+    - ``["foo", "bar"]``
+
+    Parameters
+    ----------
+    entry : Any
+        Thing to test.
+
+    Returns
+    -------
+    bool
+        True if ENTRY is _not_ field access like, otherwise False.
+
+    Examples
+    --------
+    >>> not_field_access_like(0)
+    True
+    >>> not_field_access_like("foo")
+    False
+    >>> not_field_access_like(["foo", "bar"])
+    False
+    >>> not_field_access_like(["foo", 0])
+    True
+
+    """
     if isinstance(entry, str):
         return False
     if isinstance(entry, (list, tuple)) and all(isinstance(x, str) for x in entry):

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -160,6 +160,43 @@ def field_access_like(entry: Any) -> bool:
 
 
 def field_access_to_front(seq: Sequence[Any]) -> tuple[tuple[Any, ...], int]:
+    """Move field access to the front of a sequence.
+
+    We have multiargument getitem calls we want to bring the field
+    access calls to the front. For example
+
+    >>> a[0, "foo"]
+
+    Is the same as
+
+    >>> a["foo", 0]
+
+    But the latter starts with something that is trivially
+    map-partitionable. This function helps us write out the logic for
+    getitem calls.
+
+    Parameters
+    ----------
+    seq : Sequence[Any]
+        Sequence to reorder.
+
+    Returns
+    -------
+    tuple[Any, ...]
+        Reordered sequence with field accesses brought to the front.
+    int
+        Total number of field accesses.
+
+    Examples
+    --------
+    >>> where = [0, ["foo", "bar"], "x"]
+    >>> new, n = field_access_to_front(where)
+    >>> new
+    [["foo", "bar"], "x", 0]
+    >>> n
+    2
+
+    """
     new_seq = []
     n_front = 0
     for entry in seq:

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Sequence, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -149,3 +149,23 @@ def second(seq: Iterable[T]) -> T:
     the_iter = iter(seq)
     next(the_iter)
     return next(the_iter)
+
+
+def field_access_like(entry: Any) -> bool:
+    if isinstance(entry, str):
+        return True
+    if isinstance(entry, (list, tuple)) and all(isinstance(x, str) for x in entry):
+        return True
+    return False
+
+
+def field_access_to_front(seq: Sequence[Any]) -> tuple[Any, ...]:
+    new_seq = []
+    n_front = 0
+    for entry in seq:
+        if field_access_like(entry):
+            new_seq.insert(n_front, entry)
+            n_front += 1
+        else:
+            new_seq.append(entry)
+    return tuple(new_seq)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -104,7 +104,7 @@ def test_len(ndjson_points_file: str) -> None:
     daa = dak.from_json([ndjson_points_file] * 2)
     assert not daa.known_divisions
     with pytest.raises(
-        NotImplementedError,
+        TypeError,
         match=(
             "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
             "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length.\\n"

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -161,31 +161,31 @@ def test_firstarg_ellipsis_bad() -> None:
         daa[..., 0]
 
 
-def test_multiarg_starting_with_string_gh454():
+@pytest.mark.parametrize("i", [0, 1, 2, 3])
+def test_multiarg_starting_with_string_gh454(i):
     caa = ak.Array(
         [
             [
                 {"a": 1, "b": 5},
-                {"a": 2, "b": 6},
+                {"a": -2, "b": -6},
                 {"a": 1, "b": 5},
-                {"a": 2, "b": 6},
+                {"a": -2, "b": -6},
             ],
             [
-                {"a": 1, "b": 5},
-                {"a": 2, "b": 6},
+                {"a": 1, "b": -5},
+                {"a": -2, "b": 6},
             ],
             [],
             [
-                {"a": 1, "b": 5},
-                {"a": 2, "b": 6},
+                {"a": -1, "b": 5},
+                {"a": -2, "b": 6},
             ],
         ]
     )
     daa = dak.from_awkward(caa, npartitions=2)
-    assert_eq(daa["a", 0], caa["a", 0])
-    assert_eq(daa["a", 1], caa["a", 1])
-    assert_eq(daa["a", 2], caa["a", 2])
-    assert_eq(daa["a", 3], caa["a", 3])
-    assert daa.defined_divisions
+    assert_eq(daa["a", i], caa["a", i])
+
     with pytest.raises(ValueError, match="only works when divisions are known"):
         daa["a", 0].defined_divisions
+
+    assert_eq(daa[["a", "b"], i], caa[["a", "b"], i])

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -159,3 +159,30 @@ def test_firstarg_ellipsis_bad() -> None:
         match="sliced axes is greater than",
     ):
         daa[..., 0]
+
+
+def test_multiarg_starting_with_string_gh454():
+    caa = ak.Array(
+        [
+            [
+                {"a": 1, "b": 5},
+                {"a": 2, "b": 6},
+                {"a": 1, "b": 5},
+                {"a": 2, "b": 6},
+            ],
+            [
+                {"a": 1, "b": 5},
+                {"a": 2, "b": 6},
+            ],
+            [],
+            [
+                {"a": 1, "b": 5},
+                {"a": 2, "b": 6},
+            ],
+        ]
+    )
+    daa = dak.from_awkward(caa, npartitions=2)
+    assert_eq(daa["a", 0], caa["a", 0])
+    assert daa.defined_divisions
+    with pytest.raises(ValueError, match="only works when divisions are known"):
+        daa["a", 0].defined_divisions

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -183,6 +183,9 @@ def test_multiarg_starting_with_string_gh454():
     )
     daa = dak.from_awkward(caa, npartitions=2)
     assert_eq(daa["a", 0], caa["a", 0])
+    assert_eq(daa["a", 1], caa["a", 1])
+    assert_eq(daa["a", 2], caa["a", 2])
+    assert_eq(daa["a", 3], caa["a", 3])
     assert daa.defined_divisions
     with pytest.raises(ValueError, match="only works when divisions are known"):
         daa["a", 0].defined_divisions

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -60,7 +60,7 @@ def test_json_sanity(json_data_dir: Path, concrete_data: ak.Array) -> None:
     ds = dak.from_json(source)
     assert not ds.known_divisions
     with pytest.raises(
-        NotImplementedError,
+        TypeError,
         match=(
             "Cannot determine length of collection with unknown partition sizes without executing the graph.\\n"
             "Use `dask_awkward.num\\(\\.\\.\\., axis=0\\)` if you want a lazy Scalar of the length.\\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from dask_awkward.utils import LazyInputsDict, hyphenize, is_empty_slice
+import pytest
+
+from dask_awkward.utils import (
+    LazyInputsDict,
+    hyphenize,
+    is_empty_slice,
+    field_access_to_front,
+)
 
 
 def test_is_empty_slice() -> None:
@@ -30,3 +37,36 @@ def test_hyphenize() -> None:
     assert hyphenize("with_name") == "with-name"
     assert hyphenize("with_a_name") == "with-a-name"
     assert hyphenize("ok") == "ok"
+
+
+@pytest.mark.parametrize(
+    "pairs",
+    [
+        (
+            (1, 3, 2, "z", "a"),
+            ("z", "a", 1, 3, 2),
+        ),
+        (
+            ("a", 1, 2, ["1", "2"]),
+            ("a", ["1", "2"], 1, 2),
+        ),
+        (
+            (0, ["a", "b", "c"]),
+            (["a", "b", "c"], 0),
+        ),
+        (
+            ("hello", "abc"),
+            ("hello", "abc"),
+        ),
+        (
+            (1, 2, slice(None, None, 2), 3),
+            (1, 2, slice(None, None, 2), 3),
+        ),
+        (
+            (0, ["a", 0], ["a", "b"]),
+            (["a", "b"], 0, ["a", 0]),
+        ),
+    ],
+)
+def test_field_access_to_front(pairs):
+    assert field_access_to_front(pairs[0]) == pairs[1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,9 @@ import pytest
 
 from dask_awkward.utils import (
     LazyInputsDict,
+    field_access_to_front,
     hyphenize,
     is_empty_slice,
-    field_access_to_front,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,28 +45,36 @@ def test_hyphenize() -> None:
         (
             (1, 3, 2, "z", "a"),
             ("z", "a", 1, 3, 2),
+            2,
         ),
         (
             ("a", 1, 2, ["1", "2"]),
             ("a", ["1", "2"], 1, 2),
+            2,
         ),
         (
             (0, ["a", "b", "c"]),
             (["a", "b", "c"], 0),
+            1,
         ),
         (
             ("hello", "abc"),
             ("hello", "abc"),
+            2,
         ),
         (
             (1, 2, slice(None, None, 2), 3),
             (1, 2, slice(None, None, 2), 3),
+            0,
         ),
         (
             (0, ["a", 0], ["a", "b"]),
             (["a", "b"], 0, ["a", 0]),
+            1,
         ),
     ],
 )
 def test_field_access_to_front(pairs):
-    assert field_access_to_front(pairs[0]) == pairs[1]
+    res = field_access_to_front(pairs[0])
+    assert res[0] == pairs[1]
+    assert res[1] == pairs[2]


### PR DESCRIPTION
Fix #454 

