### PR TITLE
fix: `to_{parquet,json}` retain complete path 

### DIFF
--- a/src/dask_awkward/lib/io/json.py
+++ b/src/dask_awkward/lib/io/json.py
@@ -664,7 +664,7 @@ class ToJsonFn:
                 ext = "zst"
             filename = f"{filename}.{ext}"
 
-        thispath = self.fs.sep.join([self.path, filename])
+        thispath = self.fs.unstrip_protocol(f"{self.path}{self.fs.sep}{filename}")
         with self.fs.open(thispath, mode="wt", compression=self.compression) as f:
             ak.to_json(array, f, **self.kwargs)
 

--- a/src/dask_awkward/lib/io/parquet.py
+++ b/src/dask_awkward/lib/io/parquet.py
@@ -504,7 +504,7 @@ class _ToParquetFn:
         filename = f"part{str(block_index[0]).zfill(self.zfill)}.parquet"
         if self.prefix is not None:
             filename = f"{self.prefix}-{filename}"
-        filename = f"{self.protocol}://{self.path}/{filename}"
+        filename = self.fs.unstrip_protocol(f"{self.path}{self.fs.sep}{filename}")
         return ak.to_parquet(
             data, filename, **self.kwargs, storage_options=self.storage_options
         )


### PR DESCRIPTION
Fix #458﻿
