### PR TITLE
perf: private map partitions

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1909,7 +1909,13 @@ def _map_partitions(
     **kwargs: Any,
 ) -> Array:
     """Map a callable across all partitions of any number of collections.
-    No wrapper is used to flatten the function arguments.
+    No wrapper is used to flatten the function arguments. This is meant for
+    dask-awkward internal use or in situations where input data are sanitized.
+
+    The parameters of this function are otherwise the same as map_partitions,
+    but the limitation that args, kwargs must be non-nested and flat. They
+    will not be traversed to extract all dask collections, except those in
+    the first dimension of args or kwargs.
     """
     token = token or tokenize(fn, *args, meta, **kwargs)
     label = hyphenize(label or funcname(fn))

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1212,7 +1212,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             else:
                 m = to_meta([where])[0]
                 meta = self._meta[m]
-        return map_partitions(
+        return _map_partitions(
             operator.getitem,
             self,
             where,
@@ -1232,7 +1232,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             )
 
         new_meta = self._meta[where._meta]
-        return self.map_partitions(
+        return self._map_partitions(
             operator.getitem,
             where,
             meta=new_meta,


### PR DESCRIPTION
This PR splits `map_parititions` into itself and an unsafe version `_map_partitions` which does not make the effort to sanitize input functions or data.

This avoids creating an ArgsKwargsPackedFunction when it is not necessary to do so in routine operations like getitem and fancy indexing.

Saves O(1)s in a complex analysis.