### PR TITLE
feat: more obvious names for report products

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -643,7 +643,9 @@ def from_map(
             res = result.map_partitions(
                 first, meta=array_meta, label=label, output_divisions=1
             )
-            rep = result.map_partitions(second, meta=empty_typetracer(), label=f"{label}-report")
+            rep = result.map_partitions(
+                second, meta=empty_typetracer(), label=f"{label}-report"
+            )
             return res, rep
 
     return result

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -643,7 +643,7 @@ def from_map(
             res = result.map_partitions(
                 first, meta=array_meta, label=label, output_divisions=1
             )
-            rep = result.map_partitions(second, meta=empty_typetracer(), label="report")
+            rep = result.map_partitions(second, meta=empty_typetracer(), label=f"{label}-report")
             return res, rep
 
     return result

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -640,8 +640,10 @@ def from_map(
 
     if io_func_implements_report(io_func):
         if cast(ImplementsReport, io_func).return_report:
-            res = result.map_partitions(first, meta=array_meta, output_divisions=1)
-            rep = result.map_partitions(second, meta=empty_typetracer())
+            res = result.map_partitions(
+                first, meta=array_meta, label=label, output_divisions=1
+            )
+            rep = result.map_partitions(second, meta=empty_typetracer(), label="report")
             return res, rep
 
     return result


### PR DESCRIPTION
Call the report output `report` and the from-uproot part `from-uproot` (or whatever input file format it happens to be) but with a different token key.