### PR TITLE
feat: use tree reduction to aggregate i/o report

### DIFF
--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -643,7 +643,9 @@ def from_map(
             res = result.map_partitions(
                 first, meta=array_meta, label=label, output_divisions=1
             )
-            rep = result.map_partitions(second, meta=empty_typetracer(), label=f"{label}-report")
+            rep = result.map_partitions(
+                second, meta=empty_typetracer(), label=f"{label}-report"
+            )
             return res, rep
 
     return result

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -643,7 +643,7 @@ def from_map(
             res = result.map_partitions(
                 first, meta=array_meta, label=label, output_divisions=1
             )
-            rep = result.map_partitions(second, meta=empty_typetracer(), label="report")
+            rep = result.map_partitions(second, meta=empty_typetracer(), label=f"{label}-report")
             return res, rep
 
     return result

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -640,8 +640,10 @@ def from_map(
 
     if io_func_implements_report(io_func):
         if cast(ImplementsReport, io_func).return_report:
-            res = result.map_partitions(first, meta=array_meta, output_divisions=1)
-            rep = result.map_partitions(second, meta=empty_typetracer())
+            res = result.map_partitions(
+                first, meta=array_meta, label=label, output_divisions=1
+            )
+            rep = result.map_partitions(second, meta=empty_typetracer(), label="report")
             return res, rep
 
     return result


### PR DESCRIPTION
This lets us scale past ~30k input partitions without hitting a recursion error from ak.concatenate.

@nsmith- give this a try if you have time, should only need a client-side update.