### PR TITLE
feat: add 'dak.backend' and `dak.to_list` and verify that they overload the `ak.*` versions

### DIFF
--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -18,7 +18,7 @@ from dask_awkward.lib.core import (
     map_partitions,
     partition_compatibility,
 )
-from dask_awkward.lib.describe import fields
+from dask_awkward.lib.describe import backend, fields
 from dask_awkward.lib.inspect import (
     report_necessary_buffers,
     report_necessary_columns,

--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -90,6 +90,7 @@ from dask_awkward.lib.structure import (
     singletons,
     sort,
     strings_astype,
+    to_list,
     to_packed,
     to_regular,
     unflatten,

--- a/src/dask_awkward/lib/__init__.py
+++ b/src/dask_awkward/lib/__init__.py
@@ -76,6 +76,7 @@ from dask_awkward.lib.structure import (
     singletons,
     sort,
     strings_astype,
+    to_list,
     to_packed,
     to_regular,
     unflatten,

--- a/src/dask_awkward/lib/__init__.py
+++ b/src/dask_awkward/lib/__init__.py
@@ -7,7 +7,7 @@ from dask_awkward.lib.core import (
     map_partitions,
     partition_compatibility,
 )
-from dask_awkward.lib.describe import fields
+from dask_awkward.lib.describe import backend, fields
 from dask_awkward.lib.inspect import (
     report_necessary_buffers,
     report_necessary_columns,

--- a/src/dask_awkward/lib/describe.py
+++ b/src/dask_awkward/lib/describe.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dask_awkward.lib.core import Array, Record
+import awkward as ak
+
+from dask_awkward.lib.core import Array, Record, Scalar
 
 
 def fields(collection: Array | Record) -> list[str] | None:
@@ -19,3 +21,22 @@ def fields(collection: Array | Record) -> list[str] | None:
 
     """
     return collection.fields
+
+
+def backend(*arrays: Array | Record) -> str:
+    """Get the name of the backend used by `arrays`.
+
+    Parameters
+    ----------
+        arrays : dask_awkward.Array or dask_awkward.Record
+            Array or Record collection
+
+    Returns
+    -------
+    str
+        The backend name, which is always `"typetracer"` for
+        dask-awkward arrays.
+    """
+    return ak.backend(
+        *[x._meta if isinstance(x, (Array, Record, Scalar)) else x for x in arrays]
+    )

--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -62,6 +62,7 @@ __all__ = (
     "singletons",
     "sort",
     "strings_astype",
+    "to_list",
     "to_packed",
     "to_regular",
     "unflatten",
@@ -689,6 +690,15 @@ def ones_like(
         output_divisions=1,
         attrs=attrs,
     )
+
+
+@borrow_docstring(ak.to_list)
+def to_list(array: Array) -> list:
+    """Return list/dict version of the data
+
+    Unlike most functions, this one requires a compute() of the data.
+    """
+    return array.compute().to_list()
 
 
 @borrow_docstring(ak.to_packed)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -66,9 +66,6 @@ def test_distance_behavior(
     caa1 = ak.Array(caa_p1.points, with_name="Point", behavior=behaviors)
     caa2 = ak.Array(caa_p2.points)
 
-    print(f"{ak.to_list(daa1.distance(daa2)) = }")
-    print(f"{ak.to_list(caa1.distance(caa2)) = }")
-
     assert_eq(daa1.distance(daa2), caa1.distance(caa2))
     assert_eq(np.abs(daa1), np.abs(caa1))
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -65,6 +65,10 @@ def test_distance_behavior(
     daa2 = dak.with_name(daa_p2.points, name="Point", behavior=behaviors)
     caa1 = ak.Array(caa_p1.points, with_name="Point", behavior=behaviors)
     caa2 = ak.Array(caa_p2.points)
+
+    print(f"{ak.to_list(daa1.distance(daa2)) = }")
+    print(f"{ak.to_list(caa1.distance(caa2)) = }")
+
     assert_eq(daa1.distance(daa2), caa1.distance(caa2))
     assert_eq(np.abs(daa1), np.abs(caa1))
 

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,14 +1,24 @@
+from typing import Any
+
 import awkward as ak
+import pytest
 
 import dask_awkward as dak
 
 
-def test_fields(ndjson_points_file: str) -> None:
+@pytest.mark.parametrize("quak", [ak, dak])
+def test_fields(ndjson_points_file: str, quak: Any) -> None:
     daa = dak.from_json([ndjson_points_file] * 2)
     # records fields same as array of records fields
-    assert dak.fields(daa[0].points) == dak.fields(daa.points)
+    assert quak.fields(daa[0].points) == quak.fields(daa.points)
     # computed is same as collection
-    assert dak.fields(daa) == ak.fields(daa.compute())
+    assert quak.fields(daa) == ak.fields(daa.compute())
     daa.reset_meta()
     # removed meta gives None fields
-    assert dak.fields(daa) == []
+    assert quak.fields(daa) == []
+
+
+@pytest.mark.parametrize("quak", [ak, dak])
+def test_backend(ndjson_points_file: str, quak: Any) -> None:
+    daa = dak.from_json([ndjson_points_file] * 2)
+    assert quak.backend(daa) == "typetracer"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -80,7 +80,6 @@ def test_visualize_works(daa):
         dask.compute(query, optimize_graph=True)
 
 
-@pytest.mark.xfail()
 def test_basic_root_works():
     pytest.importorskip("hist")
     pytest.importorskip("uproot")

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -80,6 +80,7 @@ def test_visualize_works(daa):
         dask.compute(query, optimize_graph=True)
 
 
+@pytest.mark.xfail()
 def test_basic_root_works():
     pytest.importorskip("hist")
     pytest.importorskip("uproot")

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -458,6 +458,10 @@ def test_to_packed(daa, caa):
     )
 
 
+def test_to_list(daa):
+    assert dak.to_list(daa) == daa.compute().to_list()
+
+
 def test_ravel(daa, caa):
     assert_eq(
         dak.ravel(daa.points.x),


### PR DESCRIPTION
The _tests_ need type annotations! That's too much, man!