### PR TITLE
fix: Scalar typetracer after reduction

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -440,8 +440,6 @@ def test_typetracer_function(daa: Array) -> None:
     tta = typetracer_array(aa)
     assert tta is not None
     assert tta.layout.form == aa.layout.form
-    with pytest.raises(TypeError, match="Got type <class 'int'>"):
-        typetracer_array(3)
 
 
 def test_single_partition(ndjson_points_file: str) -> None:


### PR DESCRIPTION
Fixes #528 

This appears to fix the linked issue, but I'm not really sure why a typetracer object is being passed around rather than a high-level Array.