### PR TITLE
[feat] Explicitly raise `TracerConversionError` when a tracer is used in a context that requires a concrete value

### DIFF
--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -15,7 +15,7 @@ Utilities to implement array behaviors for dask-awkward arrays.
 .. autosummary::
    :toctree: generated/
 
-   utils.TracerConversionError
+   utils.ConcretizationTypeError
 
 .. raw:: html
 

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,23 @@
+Errors
+------
+
+Utilities to implement array behaviors for dask-awkward arrays.
+
+
+.. currentmodule:: dask_awkward
+
+
+.. autosummary::
+   :toctree: generated/
+
+   utils.IncompatiblePartitions
+
+.. autosummary::
+   :toctree: generated/
+
+   utils.TracerConversionError
+
+.. raw:: html
+
+   <script data-goatcounter="https://dask-awkward.goatcounter.com/count"
+           async src="//gc.zgo.at/count.js"></script>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Table of Contents
    api/reducers.rst
    api/structure.rst
    api/behavior.rst
+   api/utils.rst
 
 .. toctree::
    :maxdepth: 1

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -48,9 +48,9 @@ from dask.utils import funcname, is_arraylike, key_split
 from dask_awkward.layers import AwkwardBlockwiseLayer, AwkwardMaterializedLayer
 from dask_awkward.lib.optimize import all_optimizations
 from dask_awkward.utils import (
+    ConcretizationTypeError,
     DaskAwkwardNotImplemented,
     IncompatiblePartitions,
-    TracerConversionError,
     field_access_to_front,
     first,
     hyphenize,
@@ -923,19 +923,21 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     __dask_scheduler__ = staticmethod(threaded_get)
 
     def __bool__(self):
-        raise TracerConversionError(bool, self)
+        raise ConcretizationTypeError(f"The __bool__() method was called on {self!r}.")
 
     def __int__(self):
-        raise TracerConversionError(int, self)
+        raise ConcretizationTypeError(f"The __int__() method was called on {self!r}.")
 
     def __float__(self):
-        raise TracerConversionError(float, self)
+        raise ConcretizationTypeError(f"The __float__() method was called on {self!r}.")
 
     def __complex__(self):
-        raise TracerConversionError(complex, self)
+        raise ConcretizationTypeError(
+            f"The __complex__() method was called on {self!r}."
+        )
 
     def __index__(self):
-        raise TracerConversionError(operator.index, self)
+        raise ConcretizationTypeError(f"The __index__() method was called on {self!r}.")
 
     def __setitem__(self, where: Any, what: Any) -> None:
         if not (

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -50,6 +50,7 @@ from dask_awkward.lib.optimize import all_optimizations
 from dask_awkward.utils import (
     DaskAwkwardNotImplemented,
     IncompatiblePartitions,
+    TracerConversionError,
     field_access_to_front,
     first,
     hyphenize,
@@ -921,35 +922,20 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
     __dask_scheduler__ = staticmethod(threaded_get)
 
-    # taken from https://github.com/dask/dask/blob/3003db5b84070b1afc197c7c70c76c5c4c2bc821/dask/array/core.py#L1854-L1883
     def __bool__(self):
-        materialized = self.compute().to_numpy()
-        if materialized.size != 1:
-            raise ValueError(
-                f"The truth value of a {self.__class__.__name__} is ambiguous. "
-                "Use a.any() or a.all()."
-            )
-        else:
-            return bool(materialized)
-
-    def _scalarfunc(self, cast_type):
-        materialized = self.compute().to_numpy()
-        if materialized.size != 1:
-            raise TypeError("Only length-1 arrays can be converted to Python scalars")
-        else:
-            return cast_type(materialized.item())
+        raise TracerConversionError(bool, self)
 
     def __int__(self):
-        return self._scalarfunc(int)
+        raise TracerConversionError(int, self)
 
     def __float__(self):
-        return self._scalarfunc(float)
+        raise TracerConversionError(float, self)
 
     def __complex__(self):
-        return self._scalarfunc(complex)
+        raise TracerConversionError(complex, self)
 
     def __index__(self):
-        return self._scalarfunc(operator.index)
+        raise TracerConversionError(operator.index, self)
 
     def __setitem__(self, where: Any, what: Any) -> None:
         if not (

--- a/src/dask_awkward/utils.py
+++ b/src/dask_awkward/utils.py
@@ -38,6 +38,49 @@ class IncompatiblePartitions(ValueError):
         return msg
 
 
+class TracerConversionError(TypeError):
+    """
+    This error occurs when a tracer is used in a context that requires a concrete
+    value.
+
+
+    There are several reasons why this error might occur:
+
+    Examples
+    --------
+
+    - When a tracer is used in a conditional statement:
+
+    >>> import dask_awkward as dak
+    >>> tracer = dak.from_awkward(ak.Array([1]), npartitions=1)
+    >>> bool(dask_arr)
+    Traceback (most recent call last): ...
+    TracerConversionError: Attempted to convert (``bool(dask.awkward<from-awkward, npartitions=1>)``) a Dask tracer to a concrete value. If you intend to convert the tracer to a concrete value, use the `.compute()` method.
+
+
+    - When a tracer is cast to a Python type:
+
+    >>> import dask_awkward as dak
+    >>> tracer = dak.from_awkward(ak.Array([1]), npartitions=1)
+    >>> int(dask_arr)
+    Traceback (most recent call last): ...
+    TracerConversionError: Attempted to convert (``int(dask.awkward<from-awkward, npartitions=1>)``) a Dask tracer to a concrete value. If you intend to convert the tracer to a concrete value, use the `.compute()` method.
+
+
+    These errors can be resolved by explicitely converting the tracer to a concrete value:
+
+    >>> import dask_awkward as dak
+    >>> tracer = dak.from_awkward(ak.Array([1]), npartitions=1)
+    >>> bool(tracer.compute())
+    >>> int(tracer.compute())
+    """
+
+    def __init__(self, func: Callable, array: Array):
+        self.message = f"Attempted to convert (`{func.__name__}({array!r})`) a Dask tracer to a concrete value. "
+        self.message += "If you intend to convert the tracer to a concrete value, use the `.compute()` method."
+        super().__init__(self.message)
+
+
 class LazyInputsDict(Mapping):
     """Dictionary with lazy key value pairs
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ from dask_awkward.lib.core import (
     typetracer_array,
 )
 from dask_awkward.lib.testutils import assert_eq
-from dask_awkward.utils import IncompatiblePartitions, TracerConversionError
+from dask_awkward.utils import ConcretizationTypeError, IncompatiblePartitions
 
 if TYPE_CHECKING:
     from dask_awkward.lib.core import Array
@@ -973,11 +973,11 @@ def test_map_partitions_bad_arguments():
 def test_array__bool_nonzero_long_int_float_complex_index():
     import operator
 
-    tracer = dak.from_awkward(ak.Array([1]), npartitions=1)
+    dask_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
 
     for fun in bool, int, float, complex, operator.index:
         with pytest.raises(
-            TracerConversionError,
-            match=r"Attempted to convert \(.+\) a Dask tracer to a concrete value. If you intend to convert the tracer to a concrete value, use the `.compute\(\)` method.",
+            ConcretizationTypeError,
+            match=r"A dask_awkward.Array is encountered in a computation where a concrete value is expected. If you intend to convert the dask_awkward.Array to a concrete value, use the `.compute\(\)` method. The .+ method was called on .+.",
         ):
-            fun(tracer)
+            fun(dask_arr)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -968,3 +968,27 @@ def test_map_partitions_bad_arguments():
             array2,
             meta=empty_typetracer(),
         )
+
+
+def test_array__bool_nonzero_long_int_float_complex_index():
+    import operator
+
+    dak_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
+    dask_arr = da.from_array(np.array([1]))
+
+    for fun in bool, int, float, complex, operator.index:
+        assert fun(dak_arr) == fun(dask_arr)
+
+    toolong = dak.from_awkward(ak.Array([1, 2]), npartitions=1)
+
+    with pytest.raises(
+        ValueError,
+        match=r"The truth value of a .+ is ambiguous. Use a.any\(\) or a.all\(\).",
+    ):
+        bool(toolong)
+
+    with pytest.raises(
+        TypeError, match="Only length-1 arrays can be converted to Python scalars"
+    ):
+        for fun in int, float, complex, operator.index:
+            fun(toolong)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ from dask_awkward.lib.core import (
     typetracer_array,
 )
 from dask_awkward.lib.testutils import assert_eq
-from dask_awkward.utils import IncompatiblePartitions
+from dask_awkward.utils import IncompatiblePartitions, TracerConversionError
 
 if TYPE_CHECKING:
     from dask_awkward.lib.core import Array
@@ -973,22 +973,11 @@ def test_map_partitions_bad_arguments():
 def test_array__bool_nonzero_long_int_float_complex_index():
     import operator
 
-    dak_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
-    dask_arr = da.from_array(np.array([1]))
+    tracer = dak.from_awkward(ak.Array([1]), npartitions=1)
 
     for fun in bool, int, float, complex, operator.index:
-        assert fun(dak_arr) == fun(dask_arr)
-
-    toolong = dak.from_awkward(ak.Array([1, 2]), npartitions=1)
-
-    with pytest.raises(
-        ValueError,
-        match=r"The truth value of a .+ is ambiguous. Use a.any\(\) or a.all\(\).",
-    ):
-        bool(toolong)
-
-    with pytest.raises(
-        TypeError, match="Only length-1 arrays can be converted to Python scalars"
-    ):
-        for fun in int, float, complex, operator.index:
-            fun(toolong)
+        with pytest.raises(
+            TracerConversionError,
+            match=r"Attempted to convert \(.+\) a Dask tracer to a concrete value. If you intend to convert the tracer to a concrete value, use the `.compute\(\)` method.",
+        ):
+            fun(tracer)

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -68,9 +68,9 @@ def test_json_sanity(json_data_dir: Path, concrete_data: ak.Array) -> None:
             ", use `\\.eager_compute_divisions\\(\\)` on the collection."
         ),
     ):
-        assert ds
+        assert len(ds)
     ds.eager_compute_divisions()
-    assert ds
+    assert len(ds)
 
     assert_eq(ds, concrete_data)
 


### PR DESCRIPTION
This fixes #538 by adopting to dask.Array's behavior. 

However, I think - in the long run - we should aim for avoiding "silent" `.compute()` calls like these, and rather raise exceptions.

Best, Peter