### PR TITLE
fix: allow renaming when rebuilding dask-awkward Arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pyright
+pyrightconfig.json

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -381,7 +381,7 @@ class Scalar(DaskMethodsMixin, DaskOperatorMethodMixin):
     def _rebuild(self, dsk, *, rename=None):
         name = self._name
         if rename:
-            raise ValueError("rename= unsupported in dask-awkward")
+            name = rename.get(name, name)
         return type(self)(dsk, name, self._meta, self.known_value)
 
     def __reduce__(self):
@@ -962,7 +962,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
     def _rebuild(self, dsk, *, rename=None):
         name = self.name
         if rename:
-            raise ValueError("rename= unsupported in dask-awkward")
+            name = rename.get(name, name)
         return Array(dsk, name, self._meta, divisions=self.divisions)
 
     def reset_meta(self) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,9 +167,6 @@ def test_array_rebuild(ndjson_points_file: str) -> None:
     y = daa.compute()
     assert x.tolist() == y.tolist()
 
-    with pytest.raises(ValueError, match="rename= unsupported"):
-        daa._rebuild(daa.dask, rename={"x": "y"})
-
 
 def test_type(ndjson_points_file: str) -> None:
     daa = dak.from_json([ndjson_points_file] * 2)
@@ -661,14 +658,10 @@ def test_array_persist(daa: Array) -> None:
     assert_eq(daa2, daa)
 
 
-def test_scalar_persist_and_rebuild(daa: Array) -> None:
+def test_scalar_persist(daa: Array) -> None:
     coll = daa["points"][0]["x"][0]
     coll2 = coll.persist()
     assert_eq(coll, coll2)
-
-    m = dak.max(daa.points.x, axis=None)
-    with pytest.raises(ValueError, match="rename= unsupported"):
-        m._rebuild(m.dask, rename={m._name: "max2"})
 
 
 def test_output_divisions(daa: Array) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -664,6 +664,12 @@ def test_scalar_persist(daa: Array) -> None:
     assert_eq(coll, coll2)
 
 
+def test_array_rename_when_rebuilding(daa: Array) -> None:
+    name = daa.name
+    new_name = "foobar"
+    assert daa._rebuild(dsk=daa.dask, rename={name: new_name}).name == new_name
+
+
 def test_output_divisions(daa: Array) -> None:
     assert dak.max(daa.points.y, axis=1).divisions == daa.divisions
     assert daa["points"][["x", "y"]].divisions == daa.divisions


### PR DESCRIPTION
This follows the implementation of `dask.array.Array`: https://github.com/dask/dask/blob/main/dask/array/core.py#L1442

With this PR it is possible to `dask.graph_manipulation.clone` graphs containing `dask_awkward.Arrays`.