### PR TITLE
fix: tokenization of ArgsKwargsPackedFunction

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1956,7 +1956,9 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def __repr__(self):
-        return "repacked-" + repr(self.fn).replace("<", "").replace(">", "").replace("function ", "").replace("built-in ", "")
+        return "repacked-" + repr(self.fn).replace("<", "").replace(">", "").replace(
+            "function ", ""
+        ).replace("built-in ", "")
 
     def _repack(self, *args_deps_expanded):
         """This packing function receives a list of strictly

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1966,7 +1966,15 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def __repr__(self):
-        return f"{self.fn.__qualname__}-repacked"
+        if hasattr(self.fn, "__qualname__")
+            return f"{self.fn.__qualname__}-repacked"
+        return (
+            repr(self.fn)
+            .replace("<", "")
+            .replace(">", "")
+            .replace("function ", "")
+            .replace("built-in ", "")
+        ) + "-repacked"
 
     def _repack(self, *args_deps_expanded):
         """This packing function receives a list of strictly

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1956,19 +1956,6 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def _repack(self, *args_deps_expanded):
-        args = []
-        len_args = 0
-        for repacker, n_args in zip(self.arg_repackers, self.arg_lens_for_repackers):
-            args.append(
-                repacker(args_deps_expanded[len_args : len_args + n_args])[0]
-                if repacker is not None
-                else args_deps_expanded[len_args]
-            )
-            len_args += n_args
-        kwargs = self.kwarg_repacker(args_deps_expanded[len_args:])[0]
-        return args, kwargs
-
-    def __call__(self, *args_deps_expanded):
         """This packing function receives a list of strictly
         ordered arguments. The first range of arguments,
         [0:sum(self.arg_lens_for_repackers)], corresponding to
@@ -1982,6 +1969,19 @@ class ArgsKwargsPackedFunction:
         The various repackers deal with restructuring the received flattened
         list into the shape that self.fn expects.
         """
+        args = []
+        len_args = 0
+        for repacker, n_args in zip(self.arg_repackers, self.arg_lens_for_repackers):
+            args.append(
+                repacker(args_deps_expanded[len_args : len_args + n_args])[0]
+                if repacker is not None
+                else args_deps_expanded[len_args]
+            )
+            len_args += n_args
+        kwargs = self.kwarg_repacker(args_deps_expanded[len_args:])[0]
+        return args, kwargs
+
+    def __call__(self, *args_deps_expanded):
         args, kwargs = self._repack(*args_deps_expanded)
         return self.fn(*args, **kwargs)
 

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1956,9 +1956,13 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def __repr__(self):
-        return "repacked-" + repr(self.fn).replace("<", "").replace(">", "").replace(
-            "function ", ""
-        ).replace("built-in ", "")
+        return (
+            repr(self.fn)
+            .replace("<", "")
+            .replace(">", "")
+            .replace("function ", "")
+            .replace("built-in ", "")
+        ) + "-repacked"
 
     def _repack(self, *args_deps_expanded):
         """This packing function receives a list of strictly

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1966,7 +1966,7 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def __repr__(self):
-        if hasattr(self.fn, "__qualname__")
+        if hasattr(self.fn, "__qualname__"):
             return f"{self.fn.__qualname__}-repacked"
         return (
             repr(self.fn)

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1966,13 +1966,7 @@ class ArgsKwargsPackedFunction:
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
     def __repr__(self):
-        return (
-            repr(self.fn)
-            .replace("<", "")
-            .replace(">", "")
-            .replace("function ", "")
-            .replace("built-in ", "")
-        ) + "-repacked"
+        return f"{self.fn.__qualname__}-repacked"
 
     def _repack(self, *args_deps_expanded):
         """This packing function receives a list of strictly

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1955,6 +1955,19 @@ class ArgsKwargsPackedFunction:
         self.kwarg_repacker = kwarg_repacker
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
+    def _repack(self, *args_deps_expanded):
+        args = []
+        len_args = 0
+        for repacker, n_args in zip(self.arg_repackers, self.arg_lens_for_repackers):
+            args.append(
+                repacker(args_deps_expanded[len_args : len_args + n_args])[0]
+                if repacker is not None
+                else args_deps_expanded[len_args]
+            )
+            len_args += n_args
+        kwargs = self.kwarg_repacker(args_deps_expanded[len_args:])[0]
+        return args, kwargs
+
     def __call__(self, *args_deps_expanded):
         """This packing function receives a list of strictly
         ordered arguments. The first range of arguments,
@@ -1969,16 +1982,7 @@ class ArgsKwargsPackedFunction:
         The various repackers deal with restructuring the received flattened
         list into the shape that self.fn expects.
         """
-        args = []
-        len_args = 0
-        for repacker, n_args in zip(self.arg_repackers, self.arg_lens_for_repackers):
-            args.append(
-                repacker(args_deps_expanded[len_args : len_args + n_args])[0]
-                if repacker is not None
-                else args_deps_expanded[len_args]
-            )
-            len_args += n_args
-        kwargs = self.kwarg_repacker(args_deps_expanded[len_args:])[0]
+        args, kwargs = self._repack(*args_deps_expanded)
         return self.fn(*args, **kwargs)
 
 
@@ -2000,7 +2004,12 @@ def _map_partitions(
     will not be traversed to extract all dask collections, except those in
     the first dimension of args or kwargs.
     """
-    token = token or tokenize(fn, *args, output_divisions, **kwargs)
+    if isinstance(fn, ArgsKwargsPackedFunction):
+        token_args, token_kwargs = fn._repack(*args)
+        token = token or tokenize(fn.fn, *token_args, output_divisions, **token_kwargs)
+    else:
+        token = token or tokenize(fn, *args, output_divisions, **kwargs)
+
     label = hyphenize(label or funcname(fn))
     name = f"{label}-{token}"
     deps = [a for a in args if is_dask_collection(a)] + [

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1955,6 +1955,9 @@ class ArgsKwargsPackedFunction:
         self.kwarg_repacker = kwarg_repacker
         self.arg_lens_for_repackers = arg_lens_for_repackers
 
+    def __repr__(self):
+        return "repacked-" + repr(self.fn).replace("<", "").replace(">", "").replace("function ", "").replace("built-in ", "")
+
     def _repack(self, *args_deps_expanded):
         """This packing function receives a list of strictly
         ordered arguments. The first range of arguments,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -980,3 +980,12 @@ def test_array__bool_nonzero_long_int_float_complex_index():
             match=r"A dask_awkward.Array is encountered in a computation where a concrete value is expected. If you intend to convert the dask_awkward.Array to a concrete value, use the `.compute\(\)` method. The .+ method was called on .+.",
         ):
             fun(dask_arr)
+
+
+def test_map_partitoins_deterministic_token():
+    dask_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
+
+    def f(x):
+        return x + 1
+
+    assert map_partitions(f, dask_arr).name == map_partitions(f, dask_arr).name

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -982,7 +982,7 @@ def test_array__bool_nonzero_long_int_float_complex_index():
             fun(dask_arr)
 
 
-def test_map_partitoins_deterministic_token():
+def test_map_partitions_deterministic_token():
     dask_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
 
     def f(x):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -986,6 +986,8 @@ def test_map_partitions_deterministic_token():
     dask_arr = dak.from_awkward(ak.Array([1]), npartitions=1)
 
     def f(x):
-        return x + 1
+        return x[0] + 1
 
-    assert map_partitions(f, dask_arr).name == map_partitions(f, dask_arr).name
+    assert (
+        map_partitions(f, {0: dask_arr}).name == map_partitions(f, {0: dask_arr}).name
+    )


### PR DESCRIPTION
Fixes #553.

Now, the token is generated deterministically and thus the `dak_cache` is hit correctly for multiple repetitive invocations of `dak.map_partitions` with the same arguments.

Unfortunately I couldn't use `__dask_tokenize__` because one needs to repack the `args` and `kwargs` correctly.

Not sure how much of a performance gain there is, would be nice to measure it somehow...