### PR TITLE
perf: go direct to _map_partitions in functions that receive already flat deps

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1302,7 +1302,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             else:
                 m = to_meta([where])[0]
                 meta = self._meta[m]
-        return _map_partitions(
+        return (
             operator.getitem,
             self,
             where,
@@ -1322,7 +1322,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             )
 
         new_meta = self._meta[where._meta]
-        return self._map_partitions(
+        return self.(
             operator.getitem,
             where,
             meta=new_meta,
@@ -1342,7 +1342,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
                 new_meta = self._meta[metad]
             elif isinstance(where, (str, list)):
                 new_meta = self._meta[where]
-        return self._getitem_trivial_map_partitions(where, meta=new_meta, label=label)
+        return self._getitem_trivial(where, meta=new_meta, label=label)
 
     def _getitem_outer_int(self, where: int | tuple[Any, ...]) -> Any:
         if where == 0 or (isinstance(where, tuple) and where[0] == 0):
@@ -2194,7 +2194,7 @@ def map_partitions(
     if len(kwargs) == 0:
         non_traversed_deps, _ = unpack_collections(*args, traverse=False)
         if all(
-            traversed_dep == non_traversed_dep
+            id(traversed_dep) == id(non_traversed_dep)
             for traversed_dep, non_traversed_dep in zip(flat_deps, non_traversed_deps)
         ):
             return _map_partitions(

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1302,7 +1302,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             else:
                 m = to_meta([where])[0]
                 meta = self._meta[m]
-        return (
+        return _map_partitions(
             operator.getitem,
             self,
             where,
@@ -1322,7 +1322,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
             )
 
         new_meta = self._meta[where._meta]
-        return self.(
+        return self._map_partitions(
             operator.getitem,
             where,
             meta=new_meta,
@@ -1342,7 +1342,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
                 new_meta = self._meta[metad]
             elif isinstance(where, (str, list)):
                 new_meta = self._meta[where]
-        return self._getitem_trivial(where, meta=new_meta, label=label)
+        return self._getitem_trivial_map_partitions(where, meta=new_meta, label=label)
 
     def _getitem_outer_int(self, where: int | tuple[Any, ...]) -> Any:
         if where == 0 or (isinstance(where, tuple) and where[0] == 0):

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1610,7 +1610,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
                     @wraps(cls_method)
                     def wrapper(*args, **kwargs):
-                        return self._map_partitions(
+                        return self.map_partitions(
                             _BehaviorMethodFn(attr, **kwargs),
                             *args,
                             label=hyphenize(attr),
@@ -1618,7 +1618,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
                     return wrapper
                 else:
-                    return self._map_partitions(
+                    return self.map_partitions(
                         _BehaviorPropertyFn(attr),
                         label=hyphenize(attr),
                     )
@@ -2190,6 +2190,19 @@ def map_partitions(
         for arg in args:
             message += f"- {type(arg)}"
         raise TypeError(message)
+
+    
+    if len(kwargs) == 0:
+        non_traversed_deps, _ = unpack_collections(*args, traverse=False)
+        if all(traversed_dep == non_traversed_dep for traversed_dep, non_traversed_dep in zip(flat_deps, non_traversed_deps)):
+            return _map_partitions(
+                base_fn,
+                *args, 
+                label=label,
+                token=token,
+                meta=meta,
+                output_divisions=output_divisions,
+            )
 
     arg_flat_deps_expanded = []
     arg_repackers = []

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2191,13 +2191,15 @@ def map_partitions(
             message += f"- {type(arg)}"
         raise TypeError(message)
 
-    
     if len(kwargs) == 0:
         non_traversed_deps, _ = unpack_collections(*args, traverse=False)
-        if all(traversed_dep == non_traversed_dep for traversed_dep, non_traversed_dep in zip(flat_deps, non_traversed_deps)):
+        if all(
+            traversed_dep == non_traversed_dep
+            for traversed_dep, non_traversed_dep in zip(flat_deps, non_traversed_deps)
+        ):
             return _map_partitions(
                 base_fn,
-                *args, 
+                *args,
                 label=label,
                 token=token,
                 meta=meta,

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2193,7 +2193,7 @@ def map_partitions(
 
     if len(kwargs) == 0:
         non_traversed_deps, _ = unpack_collections(*args, traverse=False)
-        if all(
+        if len(flat_deps) == len(non_traversed_deps) and all(
             id(traversed_dep) == id(non_traversed_dep)
             for traversed_dep, non_traversed_dep in zip(flat_deps, non_traversed_deps)
         ):

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1610,7 +1610,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
                     @wraps(cls_method)
                     def wrapper(*args, **kwargs):
-                        return self.map_partitions(
+                        return self._map_partitions(
                             _BehaviorMethodFn(attr, **kwargs),
                             *args,
                             label=hyphenize(attr),
@@ -1618,7 +1618,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
                     return wrapper
                 else:
-                    return self.map_partitions(
+                    return self._map_partitions(
                         _BehaviorPropertyFn(attr),
                         label=hyphenize(attr),
                     )

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -2191,7 +2191,8 @@ def map_partitions(
             message += f"- {type(arg)}"
         raise TypeError(message)
 
-    if len(kwarg_flat_deps) == 0:
+    # only allow this shortcut for new dask!
+    if len(kwarg_flat_deps) == 0 and _dask_uses_tasks:
         non_traversed_deps, _ = unpack_collections(*args, traverse=False)
         if len(flat_deps) == len(non_traversed_deps) and all(
             id(traversed_dep) == id(non_traversed_dep)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -901,7 +901,7 @@ def test_dask_array_in_map_partitions(daa, caa):
     x1.eager_compute_divisions()
     y1 = da.ones(len(x1), chunks=x1.divisions[1])
     z1 = x1 + y1
-    x2 = ak.zeros_like(caa.points.x)    
+    x2 = ak.zeros_like(caa.points.x)
     y2 = np.ones(len(x2))
     z2 = x2 + y2
     assert_eq(z1, z2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -901,8 +901,7 @@ def test_dask_array_in_map_partitions(daa, caa):
     x1.eager_compute_divisions()
     y1 = da.ones(len(x1), chunks=x1.divisions[1])
     z1 = x1 + y1
-    x2 = ak.zeros_like(caa.points.x)
-    x2.eager_compute_divisions()
+    x2 = ak.zeros_like(caa.points.x)    
     y2 = np.ones(len(x2))
     z2 = x2 + y2
     assert_eq(z1, z2)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -829,9 +829,10 @@ def test_map_partitions_args_and_kwargs_have_collection():
     zl = dak.map_partitions(my_power, xl, kwarg_y=yl)
 
     # kwargs that contain collections should be wrapped
-    assert isinstance(
-        zl.dask.layers[zl.name].task.func, dak.lib.core.ArgsKwargsPackedFunction
-    )
+    if hasattr(zl.dask.layers[zl.name], "task"):
+        assert isinstance(
+            zl.dask.layers[zl.name].task.func, dak.lib.core.ArgsKwargsPackedFunction
+        )
 
     assert_eq(zc, zl)
 
@@ -858,7 +859,8 @@ def test_map_partitions_args_and_kwargs_have_collection():
     zp = dak.map_partitions(my_power, xl, kwarg_y=2.0)
 
     # this invocation of my_power shouldn't be wrapped, no collections
-    assert zp.dask.layers[zp.name].task.func is my_power
+    if hasattr(zp.dask.layers[zp.name], "task"):
+        assert zp.dask.layers[zp.name].task.func is my_power
 
     assert_eq(zg, zp)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -754,7 +754,7 @@ def test_optimize_rewrite_layer_chains_kwargs(daa):
     def increment(x, how_much=None):
         return x + how_much
 
-    arr = ((daa.points.x + 1) + 6).map_partitions(increment, 5)
+    arr = ((daa.points.x + 1) + 6).map_partitions(increment, how_much=5)
 
     # first a simple test by calling the one optimisation directly
     dsk2 = rewrite_layer_chains(arr.dask, arr.keys)
@@ -764,7 +764,7 @@ def test_optimize_rewrite_layer_chains_kwargs(daa):
     assert out.tolist() == out2.tolist()
 
     # and now with optimise as part of the usual pipeline
-    arr = ((daa.points.x + 1) + 6).map_partitions(increment, 5)
+    arr = ((daa.points.x + 1) + 6).map_partitions(increment, how_much=5)
     out = arr.compute()
     assert out.tolist() == out2.tolist()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -828,6 +828,11 @@ def test_map_partitions_args_and_kwargs_have_collection():
     zc = my_power(xc, kwarg_y=yc)
     zl = dak.map_partitions(my_power, xl, kwarg_y=yl)
 
+    # kwargs that contain collections should be wrapped
+    assert isinstance(
+        zl.dask.layers[zl.name].task.func, dak.lib.core.ArgsKwargsPackedFunction
+    )
+
     assert_eq(zc, zl)
 
     zd = structured_function(inputs={"x": xc, "y": xc, "z": yc})
@@ -851,6 +856,9 @@ def test_map_partitions_args_and_kwargs_have_collection():
 
     zg = my_power(xc, kwarg_y=2.0)
     zp = dak.map_partitions(my_power, xl, kwarg_y=2.0)
+
+    # this invocation of my_power shouldn't be wrapped, no collections
+    assert zp.dask.layers[zp.name].task.func is my_power
 
     assert_eq(zg, zp)
 
@@ -882,6 +890,7 @@ def test_map_partitions_args_and_kwargs_have_collection():
         ccc=cc,
         ddd=dd,
     )
+
     assert_eq(res1, res2)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -902,6 +902,7 @@ def test_dask_array_in_map_partitions(daa, caa):
     y1 = da.ones(len(x1), chunks=x1.divisions[1])
     z1 = x1 + y1
     x2 = ak.zeros_like(caa.points.x)
+    x2.eager_compute_divisions()
     y2 = np.ones(len(x2))
     z2 = x2 + y2
     assert_eq(z1, z2)


### PR DESCRIPTION
Justification: if the dependencies are already flat there's no need to unpack them.