### PR TITLE
fix: relax dask version requirement and use a better check for Task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward >=2.5.1",
-  "dask >=2024.12.0;python_version>'3.9'",
-  "dask >=2023.04.0;python_version<'3.10'",
+  "dask >=2023.04.0",
   "cachetools",
   "typing_extensions >=4.8.0",
 ]

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -6,14 +6,14 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, Union, cast
 
 import dask
 
-_dask_uses_tasks = hasattr(dask, "_task_spec")
-
 from dask.blockwise import Blockwise, BlockwiseDepDict, blockwise_token
 from dask.highlevelgraph import MaterializedLayer
 from dask.layers import DataFrameTreeReduction
 from typing_extensions import TypeAlias
 
 from dask_awkward.utils import LazyInputsDict
+
+_dask_uses_tasks = hasattr(dask, "_task_spec") and hasattr(dask.blockwise, "Task")
 
 if _dask_uses_tasks:
     from dask._task_spec import Task, TaskRef

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, Union, cast
 
 import dask
-
 from dask.blockwise import Blockwise, BlockwiseDepDict, blockwise_token
 from dask.highlevelgraph import MaterializedLayer
 from dask.layers import DataFrameTreeReduction

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -15,7 +15,7 @@ from dask_awkward.utils import LazyInputsDict
 _dask_uses_tasks = hasattr(dask.blockwise, "Task")
 
 if _dask_uses_tasks:
-    from dask.blockwise import Task, TaskRef # type: ignore
+    from dask.blockwise import Task, TaskRef  # type: ignore
 
 if TYPE_CHECKING:
     from awkward import Array as AwkwardArray

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -15,7 +15,7 @@ from dask_awkward.utils import LazyInputsDict
 _dask_uses_tasks = hasattr(dask.blockwise, "Task")
 
 if _dask_uses_tasks:
-    from dask.blockwise import Task, TaskRef
+    from dask.blockwise import Task, TaskRef # type: ignore
 
 if TYPE_CHECKING:
     from awkward import Array as AwkwardArray

--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -12,10 +12,10 @@ from typing_extensions import TypeAlias
 
 from dask_awkward.utils import LazyInputsDict
 
-_dask_uses_tasks = hasattr(dask, "_task_spec") and hasattr(dask.blockwise, "Task")
+_dask_uses_tasks = hasattr(dask.blockwise, "Task")
 
 if _dask_uses_tasks:
-    from dask._task_spec import Task, TaskRef
+    from dask.blockwise import Task, TaskRef
 
 if TYPE_CHECKING:
     from awkward import Array as AwkwardArray

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -62,7 +62,7 @@ from dask_awkward.utils import (
 )
 
 if _dask_uses_tasks:
-    from dask.blockwise import TaskRef # type: ignore
+    from dask.blockwise import TaskRef  # type: ignore
 
 if TYPE_CHECKING:
     from awkward.contents.content import Content

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -62,7 +62,7 @@ from dask_awkward.utils import (
 )
 
 if _dask_uses_tasks:
-    from dask._task_spec import TaskRef
+    from dask.blockwise import TaskRef # type: ignore
 
 if TYPE_CHECKING:
     from awkward.contents.content import Content

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -22,7 +22,7 @@ from dask_awkward.lib.utils import typetracer_nochecks
 from dask_awkward.utils import first
 
 if _dask_uses_tasks:
-    from dask.blockwise import GraphNode, Task, TaskRef
+    from dask.blockwise import GraphNode, Task, TaskRef # type: ignore
 
 if TYPE_CHECKING:
     from awkward._nplikes.typetracer import TypeTracerReport

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -22,7 +22,7 @@ from dask_awkward.lib.utils import typetracer_nochecks
 from dask_awkward.utils import first
 
 if _dask_uses_tasks:
-    from dask.blockwise import GraphNode, Task, TaskRef # type: ignore
+    from dask.blockwise import GraphNode, Task, TaskRef  # type: ignore
 
 if TYPE_CHECKING:
     from awkward._nplikes.typetracer import TypeTracerReport

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -22,7 +22,7 @@ from dask_awkward.lib.utils import typetracer_nochecks
 from dask_awkward.utils import first
 
 if _dask_uses_tasks:
-    from dask._task_spec import GraphNode, Task, TaskRef
+    from dask.blockwise import GraphNode, Task, TaskRef
 
 if TYPE_CHECKING:
     from awkward._nplikes.typetracer import TypeTracerReport


### PR DESCRIPTION
@martindurant we got pretty... erm direct... feedback that backwards compatibility would be appreciated.

Also the current check was not working with very recent, but older, dask that has `Task` but it isn't used in blockwise.