### PR TITLE
docs: add better code-docs on buffer optimisation

### DIFF
--- a/src/dask_awkward/layers/layers.py
+++ b/src/dask_awkward/layers/layers.py
@@ -15,7 +15,7 @@ from dask_awkward.utils import LazyInputsDict
 _dask_uses_tasks = hasattr(dask.blockwise, "Task")
 
 if _dask_uses_tasks:
-    from dask.blockwise import Task, TaskRef  # type: ignore
+    from dask.blockwise import Task, TaskRef
 
 if TYPE_CHECKING:
     from awkward import Array as AwkwardArray

--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -62,7 +62,7 @@ from dask_awkward.utils import (
 )
 
 if _dask_uses_tasks:
-    from dask.blockwise import TaskRef  # type: ignore
+    from dask.blockwise import TaskRef
 
 if TYPE_CHECKING:
     from awkward.contents.content import Content

--- a/src/dask_awkward/lib/inspect.py
+++ b/src/dask_awkward/lib/inspect.py
@@ -121,6 +121,8 @@ def report_necessary_columns(
     r"""Get columns necessary to compute a collection
 
     This function is specific to sources that are columnar (e.g. Parquet).
+    It determines the names of IO-specific "columns" (e.g. TTree keys, 
+    or Parquet fields) that are required by the necessary-buffers optimization.
 
     Parameters
     ----------

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -23,7 +23,7 @@ from dask_awkward.lib.utils import typetracer_nochecks
 from dask_awkward.utils import first
 
 if _dask_uses_tasks:
-    from dask.blockwise import GraphNode, Task, TaskRef  # type: ignore
+    from dask.blockwise import GraphNode, Task, TaskRef 
 
 if TYPE_CHECKING:
     from awkward._nplikes.typetracer import TypeTracerReport

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -227,10 +227,10 @@ def _ak_output_layer_names(dsk: HighLevelGraph) -> list[str]:
 
 def _has_projectable_awkward_io_layer(dsk: HighLevelGraph) -> bool:
     """Check if a graph at least one AwkwardInputLayer that is project-able."""
-    for _, v in dsk.layers.items():
-        if isinstance(v, AwkwardInputLayer) and v.is_projectable:
-            return True
-    return False
+    return any(
+        isinstance(v, AwkwardInputLayer) and v.is_projectable
+        for v in dsk.layers.values()
+    )
 
 
 def _touch_all_data(*args, **kwargs):

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -23,7 +23,7 @@ from dask_awkward.lib.utils import typetracer_nochecks
 from dask_awkward.utils import first
 
 if _dask_uses_tasks:
-    from dask.blockwise import GraphNode, Task, TaskRef 
+    from dask.blockwise import GraphNode, Task, TaskRef
 
 if TYPE_CHECKING:
     from awkward._nplikes.typetracer import TypeTracerReport

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast, no_type_check
 
 import dask.config
+import awkward as ak
 from awkward.typetracer import touch_data
 from dask.blockwise import Blockwise, fuse_roots, optimize_blockwise
 from dask.core import flatten

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import warnings
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast, no_type_check
 
 import awkward as ak

--- a/src/dask_awkward/lib/optimize.py
+++ b/src/dask_awkward/lib/optimize.py
@@ -85,9 +85,17 @@ def optimize(dsk: HighLevelGraph, keys: Sequence[Key], **_: Any) -> Mapping:
 def _prepare_buffer_projection(
     dsk: HighLevelGraph, keys: Sequence[Key]
 ) -> tuple[dict[str, TypeTracerReport], dict[str, Any]] | None:
-    """Pair layer names with lists of necessary columns."""
-    import awkward as ak
+    """Prepare for buffer projection by building and evaluating a version of the graph that 
+    has been annotated for typetracer reporting.
 
+    Parameters
+    ----------
+    dsk : HighLevelGraph
+        Task graph to optimize.
+    keys : list[str]
+        Sequence of keys to optimize with respect to.
+    """
+    # Skip early if we can't meaningfully optimise any layers
     if not _has_projectable_awkward_io_layer(dsk):
         return None
 
@@ -97,24 +105,32 @@ def _prepare_buffer_projection(
 
     for name, lay in dsk.layers.items():
         if isinstance(lay, AwkwardInputLayer):
+            # The layer supports buffer projection
             if lay.is_projectable:
-                # Insert mocked array into layers, replacing generation func
-                # Keep track of mocked state
+                # Replace input layer with one that is ready for input projection using a report
+                # Store the report for subsequent retrieval, and cache the transient state
+                # that column projection later needs to finalise the optimisation
                 (
                     projection_layers[name],
                     layer_to_reports[name],
                     layer_to_projection_state[name],
                 ) = lay.prepare_for_projection()
+            # Layers that don't support buffer projection might support mocking
+            # This means that we at least do not have to compute them during evaluation of the optimisation graph
             elif lay.is_mockable:
                 projection_layers[name] = lay.mock()
+        # Layers that don't support buffer projection might support mocking
+        # This means that we at least do not have to compute them during evaluation of the optimisation graph
         elif hasattr(lay, "mock"):
             projection_layers[name] = lay.mock()
 
+    # Ensure that the buffers of each output are entirely touched
     for name in _ak_output_layer_names(dsk):
         projection_layers[name] = _mock_output(projection_layers[name])
 
     hlg = HighLevelGraph(projection_layers, dsk.dependencies)
 
+    # The caller should apply this optimisation with respect to a number of output keys
     minimal_keys: set[Key] = set()
     for k in keys:
         if isinstance(k, tuple) and len(k) == 2:
@@ -122,14 +138,17 @@ def _prepare_buffer_projection(
         else:
             minimal_keys.add(k)
 
-    # now we try to compute for each possible output layer key (leaf
+    # Now we try to compute for each possible output layer key (leaf
     # node on partition 0); this will cause the typetacer reports to
     # get correct fields/columns touched. If the result is a record or
     # an array we of course want to touch all of the data/fields.
     try:
         for layer in hlg.layers.values():
             layer.__dict__.pop("_cached_dict", None)
+
         results = get_sync(hlg, list(minimal_keys))
+
+        # Touch all the buffers associated with the given output keys
         for out in results:
             if isinstance(out, (ak.Array, ak.Record)):
                 touch_data(out)
@@ -185,14 +204,15 @@ def optimize_columns(dsk: HighLevelGraph, keys: Sequence[Key]) -> HighLevelGraph
         New, optimized task graph with column-projected ``AwkwardInputLayer``.
 
     """
+    # 1. Build-and-evaluate typetracer-annotated graph
     projection_data = _prepare_buffer_projection(dsk, keys)
     if projection_data is None:
         return dsk
 
-    # Unpack result
+    # 2. Unpack result
     layer_to_reports, layer_to_projection_state = projection_data
 
-    # Project layers using projection state
+    # 3. Project layers using projection state from (1)
     layers = dict(dsk.layers)
     for name, state in layer_to_projection_state.items():
         layers[name] = cast(AwkwardInputLayer, layers[name]).project(
@@ -432,9 +452,3 @@ def _recursive_replace(args, layer, parent, indices):
         else:
             args2.append(arg)
     return args2
-
-
-def _buffer_keys_for_layer(
-    buffer_keys: Iterable[str], known_buffer_keys: frozenset[str]
-) -> set[str]:
-    return {k for k in buffer_keys if k in known_buffer_keys}

--- a/src/dask_awkward/lib/unproject_layout.py
+++ b/src/dask_awkward/lib/unproject_layout.py
@@ -391,16 +391,14 @@ def _unproject_layout(form, layout, length, backend):
 
 
 def unproject_layout(form: Form | None, layout: Content) -> Content:
-    """Does nothing! Currently returns the passed in layout unchanged!
+    """Rehydrate a layout to include all parts of an original form.
 
-    Rehydrate a layout to include all parts of an original form.
-
-    When we perform the necessary columns optimization we drop fields
+    When we perform the necessary columns optimization, we drop fields
     that are not necessary for a computed result. Sometimes we have
-    task graphs that expect to see fields in name only (but no their
-    data). To protect against FieldNotFound exception we "unproject"
-    or "rehydrate" the layout with the original form. This reapplys
-    all original fields, but the ones that were orignally projected
+    task graphs that expect to see fields in name only (but not their
+    data). To protect against `FieldNotFound` exceptions we "unproject"
+    or "rehydrate" the layout with the original form. This restores
+    the original structure, but fields that were orignally projected
     away are data-less.
 
     Parameters


### PR DESCRIPTION
Although we are soon to rework this, I'm updating the docs in case I run out of time in my other PR reviews.

This is a good opportunity to explain how buffer optimisation currently works.

In dask-awkward, there are two separate concepts:
- `buffer` -- a 1D array of data that Awkward Array consumes in `ak.from_buffers`
- `column` -- a possibly-structured "array-like" whose structure / type depends upon the IO source.

Each IO source has its own type of `column` in this language -- uproot has `TTree` keys, whilst Parquet has `fields`. The importance of the distinction is that remapped arrays may have a convoluted "column-buffer" relationship, e.g. arrays which share the offsets _buffer_ from a singular IO source `column`.

Given that the details of buffer projection need to be defined by the IO sources (e.g. Parquet has to perform form unprojection, whilst uproot does not), it is conceptually trivial to think about these two things as separate internal-external concerns; users want to know which high-level columns are needed, whilst dask-awkward needs to know which buffers were needed.

As such, the optimisation is really more of the following conversation:

1. `dask-awkward`: 
   Hello `uproot`, can you "prepare" for buffer optimisation by giving me something to replace your input layer with, a special typetracing report, and any unknown state you might later need?
2. `uproot`: 
   Sure. Here's a new input layer that _doesn't_ require any compute, here's the typetracer report you asked for, and can you please hold on to this state for me?
3. `dask-awkward`: 
   Sure! OK, I've now build a full graph by repeating (1) for each input. Now, I will compute it, and collect the reports and states.
4. `dask-awkward`: 
   Hello `uproot`, I have determined which buffers I need to you drop, can you give me a new input layer that only loads these buffers? Here's the state that you gave me earlier!
   
In this conversation, `dask-awkward` does not need to talk about columns at all. It also does not need any special buffer name convention _besides_ that each buffer name is unique.