### PR TITLE
feat: add dak.zip_no_broadcast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
   "Topic :: Software Development",
 ]
 dependencies = [
-  "awkward >=2.5.1",
+  "awkward >=2.7.4",
   "dask >=2023.04.0",
   "cachetools",
   "typing_extensions >=4.8.0",

--- a/src/dask_awkward/__init__.py
+++ b/src/dask_awkward/__init__.py
@@ -104,5 +104,6 @@ from dask_awkward.lib.structure import (
     without_parameters,
     zeros_like,
     zip,
+    zip_no_broadcast,
 )
 from dask_awkward.version import __version__

--- a/src/dask_awkward/lib/__init__.py
+++ b/src/dask_awkward/lib/__init__.py
@@ -90,4 +90,5 @@ from dask_awkward.lib.structure import (
     without_parameters,
     zeros_like,
     zip,
+    zip_no_broadcast,
 )

--- a/src/dask_awkward/lib/io/io.py
+++ b/src/dask_awkward/lib/io/io.py
@@ -468,7 +468,7 @@ def to_dataframe(
     """
     import dask
     from dask.dataframe import DataFrame as DaskDataFrame
-    from dask.dataframe.core import new_dd_object  # type: ignore
+    from dask.dataframe.core import new_dd_object
 
     if parse_version(dask.__version__) >= parse_version("2025"):
         raise NotImplementedError(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -94,6 +94,48 @@ def test_zip_bad_input(daa: dak.Array) -> None:
         dak.zip(gd)
 
 
+def test_zip_no_broadcast_dict_input(caa: ak.Array, daa: dak.Array) -> None:
+    da1 = daa["points"]["x"]
+    da2 = daa["points"]["x"]
+    ca1 = caa["points"]["x"]
+    ca2 = caa["points"]["x"]
+
+    da_z = dak.zip_no_broadcast({"a": da1, "b": da2})
+    ca_z = ak.zip_no_broadcast({"a": ca1, "b": ca2})
+    assert_eq(da_z, ca_z)
+
+
+def test_zip_no_broadcast_list_input(caa: ak.Array, daa: dak.Array) -> None:
+    da1 = daa.points.x
+    ca1 = caa.points.x
+    dz1 = dak.zip_no_broadcast([da1, da1])
+    cz1 = ak.zip_no_broadcast([ca1, ca1])
+    assert_eq(dz1, cz1)
+    dz2 = dak.zip_no_broadcast([da1, da1, da1])
+    cz2 = ak.zip_no_broadcast([ca1, ca1, ca1])
+    assert_eq(dz2, cz2)
+
+
+def test_zip_no_broadcast_tuple_input(caa: ak.Array, daa: dak.Array) -> None:
+    da1 = daa.points.x
+    ca1 = caa.points.x
+    dz1 = dak.zip_no_broadcast((da1, da1))
+    cz1 = ak.zip_no_broadcast((ca1, ca1))
+    assert_eq(dz1, cz1)
+    dz2 = dak.zip_no_broadcast((da1, da1, da1))
+    cz2 = ak.zip_no_broadcast((ca1, ca1, ca1))
+    assert_eq(dz2, cz2)
+
+
+def test_zip_no_broadcast_bad_input(daa: dak.Array) -> None:
+    da1 = daa.points.x
+    gd = (x for x in (da1, da1))
+    with pytest.raises(
+        DaskAwkwardNotImplemented, match="only mappings or sequences are supported"
+    ):
+        dak.zip_no_broadcast(gd)
+
+
 def test_cartesian(caa: ak.Array, daa: dak.Array) -> None:
     da1 = daa["points", "x"]
     da2 = daa["points", "y"]


### PR DESCRIPTION
Awkward-array v2.7.4 introduces `ak.zip_no_broadcast` which is useful for coffea to construct arrays without touching unwanted buffer keys. This PR implements the `dak` equivalent.