### PR TITLE
fix: dtype inference in new_known_scalar

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -697,6 +697,8 @@ def new_known_scalar(
             dtype = np.dtype(int)
         elif isinstance(s, (float, np.floating)):
             dtype = np.dtype(float)
+        elif hasattr(s, "dtype"):
+            dtype = getattr(s, "dtype")
         else:
             dtype = np.dtype(type(s))
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -466,6 +466,14 @@ def test_new_known_scalar() -> None:
     assert c.compute() == s1
 
 
+def test_new_known_scalar_from_array() -> None:
+    s = np.array(0.0)
+    c = new_known_scalar(s)
+    assert c.compute() == s
+    assert c._meta is not None
+    assert c.dtype == s.dtype
+
+
 def test_scalar_dtype() -> None:
     s = 2
     c = new_known_scalar(s)


### PR DESCRIPTION
closes https://github.com/dask-contrib/dask-awkward/issues/577

if a 0-dim array is passed to `new_known_scalar` the dtype was inferred to be `np.dtype(type(array(...)))` which results in object dtype. This PR directly uses the dtype of the input arg if it has a dtype attribute, which is true for array types.