### PR TITLE
fix: length 0 slices

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -1434,7 +1434,7 @@ class Array(DaskMethodsMixin, NDArrayOperatorsMixin):
 
         if not self.known_divisions:
             self.eager_compute_divisions()
-        stop = sl.stop or self.defined_divisions[-1]
+        stop = self.defined_divisions[-1] if sl.stop is None else sl.stop
         start = start if start >= 0 else self.defined_divisions[-1] + start
         stop = stop if stop >= 0 else self.defined_divisions[-1] + stop
         if step < 0:

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -85,6 +85,11 @@ def test_single_ellipsis(daa: dak.Array, caa: ak.Array) -> None:
     assert_eq(daa[...], caa[...])
 
 
+def test_length0_slice(daa: dak.Array, caa: ak.Array) -> None:
+    assert_eq(daa[0:0], caa[0:0])
+    assert len(daa[0:0]) == len(caa[0:0]) == 0
+
+
 def test_empty_slice(daa: dak.Array, caa: ak.Array) -> None:
     assert_eq(daa[:], caa[:])
     assert_eq(daa[:, "points"], caa[:, "points"])


### PR DESCRIPTION
This fixes slices like `array[0:0]`. Without this PR dask-awkward would wrongly slice nothing at all, ie returning the original unsliced array.  