### PR TITLE
fix: avoid dask v2025.4.0 for CI tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward >=2.5.1",
-  "dask >=2023.04.0,!=2025.4.0",
+  "dask >=2023.04.0,<2025.4.0",
   "cachetools",
   "typing_extensions >=4.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward >=2.5.1",
-  "dask >=2023.04.0",
+  "dask >=2023.04.0,!=2025.4.0",
   "cachetools",
   "typing_extensions >=4.8.0",
 ]


### PR DESCRIPTION
Our CI is broken since: https://github.com/dask/dask/pull/11859#issuecomment-2828709361

Need to get a corresponding fix in dask.

Even though the actual code seems to run judging from playing around, I'd be in favor of avoiding this dask release as we can't be entirely sure given that our tests won't run...