### PR TITLE
fix: Add including_unknown kwarg to values_astype

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -961,6 +961,7 @@ def unzip(
 def values_astype(
     array: Array,
     to: np.dtype | str,
+    including_unknown: bool = False,
     highlevel: bool = True,
     behavior: Mapping | None = None,
     attrs: Mapping[str, Any] | None = None,
@@ -971,6 +972,7 @@ def values_astype(
         ak.values_astype,
         array,
         to=to,
+        including_unknown=including_unknown,
         behavior=behavior,
         label="values-astype",
         attrs=attrs,


### PR DESCRIPTION
Update the available keywords in `dak.values_astype`'s signature to match those of `ak.values_astype`