### PR TITLE
fix: remove known scalar optimization from `dak.num`

### DIFF
--- a/src/dask_awkward/lib/structure.py
+++ b/src/dask_awkward/lib/structure.py
@@ -20,7 +20,6 @@ from dask_awkward.lib.core import (
     PartitionCompatibility,
     _map_partitions,
     map_partitions,
-    new_known_scalar,
     new_scalar_object,
     partition_compatibility,
 )


### PR DESCRIPTION
This optimization is causing a headache to some users. The reason is that the users typically use `dak.num` on axis=0 to keep track of the number of events they processed. The problem is that if you know the divisions and yet you fail to read a partition due to some file access error (pretty common), you will have failed to read a chunk of events yet `dak.num` is going to report a fixed number `array.defined_divisions[-1]`. This causes users to over estimate the number of events they process.

I claim that this optimization is causing more problems than it solves, therefore I propose to disable it.
If a user wants the number without doing any computation, they can just use `array.defined_divisions[-1]`.
We also can't add an argument to `dak.num` because the whole point is that the function should have the same. arguments as `ak.num` (+ automatic dispatching).