### PR TITLE
feat: handle virtual array in pickling

### DIFF
--- a/src/dask_awkward/pickle.py
+++ b/src/dask_awkward/pickle.py
@@ -15,6 +15,8 @@ def _maybe_make_pickle_buffer(buffer: Any) -> PlaceholderArray | PickleBuffer:
     if isinstance(buffer, PlaceholderArray):
         return buffer
     else:
+        if hasattr(buffer, "materialize") and callable(buffer.materialize):
+            buffer = buffer.materialize()
         return PickleBuffer(buffer)
 
 


### PR DESCRIPTION
Dask-awkward registers a global pickler which will be used if someone tries to pickle an `ak.Array` if dask-awkward just exists in the environment (not even imported). Therefore it should handle virtual buffers too by simply materializing them. Users may run into `TypeError: a bytes-like object is required, not 'VirtualNDArray'` otherwise coming from `PickleBuffer`.

This was the easiest way for me to not break backwards compatibility with earlier versions of awkward and also not doing try except statements with `ImportError` to check if awkward is new-enough to implement virtual arrays. Let me know if you think there is a nicer way.