### PR TITLE
fix: make dask_property picklable

### DIFF
--- a/src/dask_awkward/lib/core.py
+++ b/src/dask_awkward/lib/core.py
@@ -131,6 +131,22 @@ F = TypeVar("F", bound=Callable)
 G = TypeVar("G", bound=Callable)
 
 
+def _rebuild_dask_property(
+    fget: Callable | None,
+    fset: Callable | None,
+    fdel: Callable | None,
+    doc: str | None,
+    dask_get: Callable | None,
+) -> _DaskProperty:
+    """Reconstruct a `_DaskProperty` when unpickling."""
+    prop = _DaskProperty(fget, fset, fdel)
+    # a doc passed to property() lands in a C slot which, before 3.13, the
+    # subclass' own docstring shadows -- so assign it to the instance instead
+    prop.__doc__ = doc
+    prop._dask_get = dask_get
+    return prop
+
+
 class _DaskProperty(property):
     """A property descriptor that exposes a `.dask` method for registering
     dask-awkward descriptor implementations.
@@ -142,6 +158,16 @@ class _DaskProperty(property):
         assert self._dask_get is None
         self._dask_get = _make_dask_descriptor(func)
         return self
+
+    def __reduce__(self) -> tuple:
+        # property keeps fget/fset/fdel in C slots and offers no reduction of
+        # its own, so a class carrying a dask_property cannot be pickled by
+        # value (which is what cloudpickle does for classes defined in
+        # __main__ or a notebook) unless we provide one.
+        return (
+            _rebuild_dask_property,
+            (self.fget, self.fset, self.fdel, self.__doc__, self._dask_get),
+        )
 
 
 def _adapt_naive_dask_get(func: Callable) -> Callable:

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -106,3 +106,63 @@ def test_nonexistent_behavior(daa_p1: dak.Array, daa_p2: dak.Array) -> None:
     # in this case the field check is where we raise
     with pytest.raises(AttributeError, match="distance not in fields"):
         daa2.distance(daa1)
+
+
+def test_dask_property_is_picklable() -> None:
+    """Classes defined outside an importable module (``__main__``, a notebook)
+    get pickled by value, which walks the class dict -- and plain property
+    objects cannot be pickled.
+    """
+    cloudpickle = pytest.importorskip("cloudpickle")
+
+    class Thing:
+        def __init__(self, x):
+            self.x = x
+
+        @dak.dask_property
+        def doubled(self):
+            """twice x"""
+            return 2 * self.x
+
+        @no_type_check
+        @doubled.dask
+        def doubled(self, array):
+            return 20 * array.x
+
+        @dak.dask_property(no_dispatch=True)
+        def tripled(self):
+            return 3 * self.x
+
+    # defined in a function body, so this has to go by value
+    unpickled = cloudpickle.loads(cloudpickle.dumps(Thing))
+
+    assert unpickled(1).doubled == 2
+    assert unpickled(1).tripled == 3
+
+    doubled = unpickled.__dict__["doubled"]
+    assert doubled.__doc__ == "twice x"
+    assert doubled._dask_get(unpickled(1), unpickled, Thing(3)) == 60
+    assert unpickled.__dict__["tripled"]._dask_get(unpickled(2), unpickled, None) == 6
+
+
+def test_dask_method_is_picklable() -> None:
+    cloudpickle = pytest.importorskip("cloudpickle")
+
+    class Thing:
+        def __init__(self, x):
+            self.x = x
+
+        @dak.dask_method
+        def scaled(self, n):
+            return self.x * n
+
+        @no_type_check
+        @scaled.dask
+        def scaled(self, array, n):
+            return array.x * n * 10
+
+    unpickled = cloudpickle.loads(cloudpickle.dumps(Thing))
+
+    assert unpickled(2).scaled(3) == 6
+    scaled = unpickled.__dict__["scaled"]
+    assert scaled._dask_get(unpickled(2), unpickled, Thing(2))(3) == 60


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A class using `@dask_property` cannot be pickled by value:

```python
import cloudpickle
import dask_awkward as dak

class Thing:
    @dak.dask_property
    def foo(self):
        return 1

    @foo.dask
    def foo(self, array):
        return 2

cloudpickle.dumps(Thing)
# TypeError: cannot pickle '_DaskProperty' object
```

`property` keeps `fget`/`fset`/`fdel` in C-level slots and provides no reduction of its own, so CPython refuses outright — `pickle.dumps(property(f))` raises the same error. `_DaskProperty` inherits that refusal even though it does have an instance `__dict__`.

This matters because cloudpickle only pickles a class by reference when it is reachable as `getattr(module, cls.__qualname__)`. Anything else — a behavior mixin written in `__main__` or in a notebook cell, or one whose generated `*Record`/`*Array` classes have been shadowed in their module — gets pickled by value, which walks the class dict and hits the property. The result is that such behaviors cannot be sent to a distributed worker at all.

`_DaskProperty` now defines `__reduce__`, round-tripping `fget`/`fset`/`fdel`/`__doc__`/`_dask_get`.

`_DaskMethod` needs no change: it is a plain Python class whose whole state lives in the instance `__dict__`, so the default reduction already handles it and cloudpickle serializes the contained function and closure by value. It gets a test to keep it that way.

Found while debugging the coffea side of this, where the same copy of `_DaskProperty` broke `FCCSchema` under a distributed client: scikit-hep/coffea#1603.
